### PR TITLE
ci: change workflow trigger from push to pull request

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [ push ]
+on: [ pull_request ]
 jobs:
   integration-test:
     name: Integration Test


### PR DESCRIPTION
- Update GitHub Actions workflow to run on pull_request instead of push
- This change improves CI efficiency by running tests only on PR creations