### PR TITLE
build: upgrade JUnit and add test platform launcher

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,7 @@ configure(libraryProjects) {
 
     dependencies {
         api(platform(dependenciesProject))
+        testImplementation(platform(rootProject.libs.junit.bom))
         detektPlugins(platform(dependenciesProject))
         jmh(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
@@ -146,6 +147,7 @@ configure(libraryProjects) {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }
         testImplementation("org.junit.jupiter:junit-jupiter-api")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
         jmh("org.openjdk.jmh:jmh-core")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ guava = "33.4.8-jre"
 kotlin-logging = "7.0.7"
 commons-io = "2.19.0"
 springdoc = "2.8.8"
+junit = "5.13.0"
 hamcrest = "3.0"
 mockk = "1.14.2"
 jmh = "1.37"
@@ -28,6 +29,7 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
- Add JUnit BOM (Bill of Materials) to manage test dependencies
- Include JUnit platform launcher for test execution
- Update gradle/libs.versions.toml to specify JUnit version