### PR TITLE
build(cosky-rest-api): update OpenAPI dependency and simplify SwaggerConfiguration

### DIFF
--- a/cosky-rest-api/build.gradle.kts
+++ b/cosky-rest-api/build.gradle.kts
@@ -70,6 +70,7 @@ application {
 dependencies {
     kapt(platform(project(":cosky-dependencies")))
     implementation(platform(project(":cosky-dependencies")))
+    implementation("me.ahoo.cosec:cosec-openapi")
     implementation("me.ahoo.cosec:cosec-webflux")
     implementation("me.ahoo.cosec:cosec-spring-boot-starter")
     implementation("io.netty:netty-all")

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/configuration/SwaggerConfiguration.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/configuration/SwaggerConfiguration.kt
@@ -12,13 +12,10 @@
  */
 package me.ahoo.cosky.rest.configuration
 
-import io.swagger.v3.oas.models.Components
-import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.info.License
-import io.swagger.v3.oas.models.security.SecurityRequirement
-import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -34,21 +31,12 @@ class SwaggerConfiguration {
         .description("High-performance, low-cost microservice governance platform. Service Discovery and Configuration Service.")
         .contact(Contact().name("Ahoo Wang").url("https://github.com/Ahoo-Wang/CoSky"))
         .license(License().url("https://github.com/Ahoo-Wang/CoSky/blob/main/LICENSE").name("Apache 2.0"))
-        .version("3.3.0")
+        .version("4.9.0")
 
     @Bean
-    fun openApi(): OpenAPI = OpenAPI().apply {
-        info(apiInfo)
-        addSecurityItem(SecurityRequirement().addList("api_key"))
-        components(Components())
-        components.addSecuritySchemes(
-            "api_key",
-            SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
-                .`in`(SecurityScheme.In.HEADER)
-                .name("Authorization")
-                .description("API Key")
-                .bearerFormat("JWT"),
-        )
+    fun coskyOpenApiCustomizer(): OpenApiCustomizer {
+        return OpenApiCustomizer {
+            it.info(apiInfo)
+        }
     }
 }


### PR DESCRIPTION
- Add cosec-openapi dependency to the project
- Remove redundant OpenAPI setup code from SwaggerConfiguration
- Update API version to 4.9.0
- Replace complex OpenAPI configuration with a simpler OpenApiCustomizer