### PR TITLE
test: replace hamcrest with fluent-assert

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,6 @@ configure(libraryProjects) {
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("me.ahoo.test:fluent-assert-core")
-        testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }

--- a/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/ConfigServiceSpec.kt
+++ b/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/ConfigServiceSpec.kt
@@ -4,8 +4,7 @@ import me.ahoo.cosid.test.MockIdGenerator
 import me.ahoo.cosky.config.ConfigRollback
 import me.ahoo.cosky.config.ConfigService
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
@@ -51,9 +50,9 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfig(namespace, testConfigId)
             .test()
             .expectNextMatches {
-                assertThat(testConfigId, equalTo(it.configId))
-                assertThat(getConfigData, equalTo(it.data))
-                assertThat(1, equalTo(it.version))
+                it.configId.assert().isEqualTo(testConfigId)
+                it.data.assert().isEqualTo(getConfigData)
+                it.version.assert().isEqualTo(1)
                 true
             }
             .verifyComplete()
@@ -89,7 +88,7 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfig(namespace, testConfigId)
             .test()
             .expectNextMatches {
-                assertThat(it.data, equalTo(version1Data))
+                it.data.assert().isEqualTo(version1Data)
                 true
             }
             .verifyComplete()
@@ -101,7 +100,7 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfig(namespace, testConfigId)
             .test()
             .expectNextMatches {
-                assertThat(it.data, equalTo(version2Data))
+                it.data.assert().isEqualTo(version2Data)
                 true
             }
             .verifyComplete()
@@ -112,7 +111,7 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfig(namespace, testConfigId)
             .test()
             .expectNextMatches {
-                assertThat(it.data, equalTo(version1Data))
+                it.data.assert().isEqualTo(version1Data)
                 true
             }
             .verifyComplete()
@@ -159,8 +158,8 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfigVersions(namespace, testConfigId)
             .test()
             .expectNextMatches {
-                assertThat(it.configId, equalTo(testConfigId))
-                assertThat(it.version, equalTo(1))
+                it.configId.assert().isEqualTo(testConfigId)
+                it.version.assert().isEqualTo(1)
                 true
             }
             .verifyComplete()
@@ -179,10 +178,10 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfigVersions(namespace, testConfigId).collectList()
             .test()
             .expectNextMatches {
-                assertThat(it.size, equalTo(ConfigRollback.HISTORY_SIZE))
+                it.size.assert().isEqualTo(ConfigRollback.HISTORY_SIZE)
                 val configVersion = it.first()
-                assertThat(configVersion.configId, equalTo(testConfigId))
-                assertThat(configVersion.version, equalTo(ConfigRollback.HISTORY_SIZE * 2))
+                configVersion.configId.assert().isEqualTo(testConfigId)
+                configVersion.version.assert().isEqualTo(ConfigRollback.HISTORY_SIZE * 2)
                 true
             }
             .verifyComplete()
@@ -196,8 +195,8 @@ abstract class ConfigServiceSpec : AbstractReactiveRedisTest() {
         configService.getConfigHistory(namespace, testConfigId, 1)
             .test()
             .expectNextMatches {
-                assertThat(it.configId, equalTo(testConfigId))
-                assertThat(it.version, equalTo(1))
+                it.configId.assert().isEqualTo(testConfigId)
+                it.version.assert().isEqualTo(1)
                 true
             }
             .verifyComplete()

--- a/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigServiceTest.kt
+++ b/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigServiceTest.kt
@@ -14,8 +14,7 @@ package me.ahoo.cosky.config.redis
 
 import me.ahoo.cosid.test.MockIdGenerator
 import me.ahoo.cosky.config.ConfigService
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer
@@ -53,9 +52,9 @@ internal class RedisConsistencyConfigServiceTest : ConfigServiceSpec() {
         configService.getConfig(namespace, testConfigId)
             .test()
             .expectNextMatches {
-                assertThat(it.configId, equalTo(testConfigId))
-                assertThat(it.data, equalTo(getConfigData))
-                assertThat(it.version, equalTo(1))
+                it.configId.assert().isEqualTo(testConfigId)
+                it.data.assert().isEqualTo(getConfigData)
+                it.version.assert().isEqualTo(1)
                 true
             }
             .verifyComplete()

--- a/cosky-dependencies/build.gradle.kts
+++ b/cosky-dependencies/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
         api(libs.kotlin.logging)
         api(libs.commons.io)
         api(libs.springdoc.openapi.starter.webflux.ui)
-        api(libs.hamcrest)
         api(libs.mockk)
         api(libs.jmh.core)
         api(libs.jmh.generator.annprocess)

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/ConsistencyRedisServiceDiscoveryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/ConsistencyRedisServiceDiscoveryTest.kt
@@ -21,7 +21,7 @@ import me.ahoo.cosky.discovery.redis.RedisServiceDiscovery
 import me.ahoo.cosky.discovery.redis.RedisServiceEventListenerContainer
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.junit.jupiter.api.Assertions
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer
 import reactor.kotlin.test.test
@@ -153,7 +153,7 @@ class ConsistencyRedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
             .test()
             .expectNext(true)
             .verifyComplete()
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
         serviceDiscovery.getServices(namespace).collectList()
             .test()
             .expectNextMatches { it.contains(serviceId) }
@@ -163,13 +163,13 @@ class ConsistencyRedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
             .test()
             .expectNext(true)
             .verifyComplete()
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
         serviceDiscovery.getServices(namespace).collectList()
             .test()
             .expectNextMatches {
-                Assertions.assertTrue(it.contains(serviceId))
-                Assertions.assertTrue(it.contains(serviceId2))
-                Assertions.assertEquals(2, it.size)
+                it.contains(serviceId).assert().isTrue()
+                it.contains(serviceId2).assert().isTrue()
+                it.size.assert().isEqualTo(2)
                 true
             }
             .verifyComplete()
@@ -199,7 +199,7 @@ class ConsistencyRedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
             .test()
             .expectNext(true)
             .verifyComplete()
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
         serviceDiscovery.getInstances(namespace, serviceId).collectList()
             .test()
             .expectNextMatches { it.contains(instance) }
@@ -207,7 +207,7 @@ class ConsistencyRedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
         StepVerifier.create(serviceRegistry.deregister(namespace, instance))
             .expectNext(true)
             .verifyComplete()
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
         serviceDiscovery.getInstances(namespace, serviceId)
             .test()
             .expectNextCount(0)
@@ -225,27 +225,27 @@ class ConsistencyRedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
             .expectNext(true)
             .verifyComplete()
 
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
 
         serviceRegistry.setMetadata(namespace, instance.serviceId, instance.instanceId, mapOf("key" to "value"))
             .test()
             .expectNext(true)
             .verifyComplete()
 
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
 
         serviceRegistry.register(namespace, instance)
             .test()
             .expectNext(true)
             .verifyComplete()
 
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
 
         serviceRegistry.deregister(namespace, instance)
             .test()
             .expectNext(true)
             .verifyComplete()
 
-        Assertions.assertTrue(semaphore.tryAcquire(1, TimeUnit.SECONDS))
+        semaphore.tryAcquire(1, TimeUnit.SECONDS).assert().isTrue()
     }
 }

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/DiscoveryKeyGeneratorTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/DiscoveryKeyGeneratorTest.kt
@@ -16,8 +16,7 @@ import me.ahoo.cosky.core.CoSky
 import me.ahoo.cosky.discovery.DiscoveryKeyGenerator.getInstanceIdxKey
 import me.ahoo.cosky.discovery.DiscoveryKeyGenerator.getInstanceKey
 import me.ahoo.cosky.discovery.DiscoveryKeyGenerator.getServiceIdxKey
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 /**
@@ -27,18 +26,18 @@ class DiscoveryKeyGeneratorTest {
     @Test
     fun getServiceIdxKey() {
         val key = getServiceIdxKey(CoSky.COSKY)
-        assertThat(key, equalTo("cosky:svc_idx"))
+        key.assert().isEqualTo("cosky:svc_idx")
     }
 
     @Test
     fun serviceInstanceIdxKey() {
         val key = getInstanceIdxKey(CoSky.COSKY, "order_service")
-        assertThat(key, equalTo("cosky:svc_itc_idx:order_service"))
+        key.assert().isEqualTo("cosky:svc_itc_idx:order_service")
     }
 
     @Test
     fun getInstanceKey() {
         val key = getInstanceKey(CoSky.COSKY, "http#127.0.0.1#8080@order_service")
-        assertThat(key, equalTo("cosky:svc_itc:http#127.0.0.1#8080@order_service"))
+        key.assert().isEqualTo("cosky:svc_itc:http#127.0.0.1#8080@order_service")
     }
 }

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/InstanceIdGeneratorTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/InstanceIdGeneratorTest.kt
@@ -13,8 +13,7 @@
 package me.ahoo.cosky.discovery
 
 import me.ahoo.cosky.discovery.Instance.Companion.asInstance
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 /**
@@ -24,18 +23,16 @@ class InstanceIdGeneratorTest {
 
     @Test
     fun asInstanceId() {
-        assertThat(
-            Instance.asInstanceId("order_service", "http", "127.0.0.1", 8080),
-            equalTo("order_service@http#127.0.0.1#8080"),
-        )
+        Instance.asInstanceId("order_service", "http", "127.0.0.1", 8080)
+            .assert().isEqualTo("order_service@http#127.0.0.1#8080")
     }
 
     @Test
     fun asInstance() {
         val actual = "order_service@http#127.0.0.1#8080".asInstance()
-        assertThat(actual.serviceId, equalTo("order_service"))
-        assertThat(actual.schema, equalTo("http"))
-        assertThat(actual.host, equalTo("127.0.0.1"))
-        assertThat(actual.port, equalTo(8080))
+        actual.serviceId.assert().isEqualTo("order_service")
+        actual.schema.assert().isEqualTo("http")
+        actual.host.assert().isEqualTo("127.0.0.1")
+        actual.port.assert().isEqualTo(8080)
     }
 }

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceDiscoveryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceDiscoveryTest.kt
@@ -17,8 +17,7 @@ import me.ahoo.cosky.discovery.TestServiceInstance.registerRandomInstanceAndTest
 import me.ahoo.cosky.discovery.redis.RedisServiceDiscovery
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
@@ -94,7 +93,7 @@ class RedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
             redisServiceDiscovery.getInstanceTtl(namespace, it.serviceId, it.instanceId)
                 .test()
                 .expectNextMatches {
-                    assertThat(it, greaterThan(0L))
+                    it.assert().isGreaterThan(0)
                     true
                 }
                 .verifyComplete()
@@ -112,7 +111,7 @@ class RedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
         redisServiceDiscovery.getInstance(namespace, fixedInstance.serviceId, fixedInstance.instanceId)
             .test()
             .expectNextMatches {
-                assertThat(it, equalTo(fixedInstance))
+                it.assert().isEqualTo(fixedInstance)
                 true
             }
             .verifyComplete()
@@ -120,7 +119,7 @@ class RedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
         redisServiceDiscovery.getInstances(namespace, fixedInstance.serviceId)
             .test()
             .expectNextMatches {
-                assertThat(it, equalTo(fixedInstance))
+                it.assert().isEqualTo(fixedInstance)
                 true
             }
             .verifyComplete()
@@ -128,7 +127,7 @@ class RedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
         redisServiceDiscovery.getInstanceTtl(namespace, fixedInstance.serviceId, fixedInstance.instanceId)
             .test()
             .expectNextMatches {
-                assertThat(it, equalTo(-1L))
+                it.assert().isEqualTo(-1L)
                 true
             }
             .verifyComplete()

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceStatisticTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceStatisticTest.kt
@@ -18,8 +18,7 @@ import me.ahoo.cosky.discovery.redis.RedisInstanceEventListenerContainer
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.discovery.redis.RedisServiceStatistic
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer
 import reactor.kotlin.test.test
@@ -53,9 +52,9 @@ class RedisServiceStatisticTest : AbstractReactiveRedisTest() {
         redisServiceStatistic.getServiceStats(namespace).collectList()
             .test()
             .expectNextMatches {
-                assertThat(it.size, equalTo(1))
+                it.size.assert().isEqualTo(1)
                 val (_, instanceCount) = it[0]
-                assertThat(instanceCount, equalTo(1))
+                instanceCount.assert().isEqualTo(1)
                 true
             }
     }

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RenewInstanceServiceTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RenewInstanceServiceTest.kt
@@ -17,8 +17,7 @@ import me.ahoo.cosky.discovery.TestServiceInstance.randomFixedInstance
 import me.ahoo.cosky.discovery.TestServiceInstance.randomInstance
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Duration
@@ -50,7 +49,7 @@ class RenewInstanceServiceTest : AbstractReactiveRedisTest() {
                 renewProperties = renewProperties,
                 serviceRegistry = redisServiceRegistry,
                 hookOnRenew = {
-                    assertThat(it, equalTo(testInstance))
+                    it.assert().isEqualTo(testInstance)
                     semaphore.release()
                 },
             )
@@ -63,13 +62,10 @@ class RenewInstanceServiceTest : AbstractReactiveRedisTest() {
             .test()
             .expectNext(true)
             .verifyComplete()
-        assertThat(
-            semaphore.tryAcquire(
-                renewProperties.initialDelay.plusSeconds(2).seconds,
-                TimeUnit.SECONDS,
-            ),
-            equalTo(true),
-        )
+        semaphore.tryAcquire(
+            renewProperties.initialDelay.plusSeconds(2).seconds,
+            TimeUnit.SECONDS,
+        ).assert().isEqualTo(true)
 
         renewService.stop()
     }

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/loadbalancer/ChooserSpec.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/loadbalancer/ChooserSpec.kt
@@ -3,8 +3,7 @@ package me.ahoo.cosky.discovery.loadbalancer
 import me.ahoo.cosky.discovery.ServiceInstance
 import me.ahoo.cosky.discovery.ServiceInstance.Companion.withWeight
 import me.ahoo.cosky.discovery.TestServiceInstance
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.util.StopWatch
 import java.util.concurrent.TimeUnit
@@ -38,7 +37,7 @@ abstract class ChooserSpec {
         )
         val chooser = createChooser(instances)
         val instance = chooser.choose()
-        assertThat(instance, notNullValue())
+        instance.assert().isNotNull()
 
         var instance1Hits = 0
         var instance2Hits = 0
@@ -64,9 +63,9 @@ abstract class ChooserSpec {
             val instance1HitRate = instance1Hits * 1.0 / instance1ExpectedHits
             val instance2HitRate = instance2Hits * 1.0 / instance2ExpectedHits
             val instance3HitRate = instance3Hits * 1.0 / instance3ExpectedHits
-            assertThat(instance1HitRate, greaterThan(expected))
-            assertThat(instance2HitRate, greaterThan(expected))
-            assertThat(instance3HitRate, greaterThan(expected))
+            instance1HitRate.assert().isGreaterThan(expected)
+            instance2HitRate.assert().isGreaterThan(expected)
+            instance3HitRate.assert().isGreaterThan(expected)
             log.info(
                 "totalTimes: {},instance1Count: {},instance2Count: {},instance3Count: {},time: {}ms",
                 totalTimes,

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/loadbalancer/RandomLoadBalancerTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/loadbalancer/RandomLoadBalancerTest.kt
@@ -21,8 +21,7 @@ import me.ahoo.cosky.discovery.redis.RedisInstanceEventListenerContainer
 import me.ahoo.cosky.discovery.redis.RedisServiceDiscovery
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer
@@ -60,7 +59,7 @@ internal class RandomLoadBalancerTest : AbstractReactiveRedisTest() {
             randomLoadBalancer.choose(namespace, it.serviceId)
                 .test()
                 .expectNextMatches { serviceInstance ->
-                    assertThat(serviceInstance, equalTo(it))
+                    serviceInstance.assert().isEqualTo(it)
                     true
                 }
         }
@@ -76,7 +75,7 @@ internal class RandomLoadBalancerTest : AbstractReactiveRedisTest() {
         redisServiceRegistry.register(namespace, instance2).block()
         redisServiceRegistry.register(namespace, instance3).block()
         val expectedInstance = randomLoadBalancer.choose(namespace, serviceId).block()
-        assertThat(expectedInstance, notNullValue())
+        expectedInstance.assert().isNotNull()
         requireNotNull(expectedInstance)
         val succeeded =
             expectedInstance.instanceId == instance1.instanceId || expectedInstance.instanceId == instance2.instanceId || expectedInstance.instanceId == instance3.instanceId

--- a/cosky-spring-cloud-core/src/test/kotlin/me/ahoo/cosky/spring/cloud/CoSkyAutoConfigurationTest.kt
+++ b/cosky-spring-cloud-core/src/test/kotlin/me/ahoo/cosky/spring/cloud/CoSkyAutoConfigurationTest.kt
@@ -13,7 +13,6 @@ internal class CoSkyAutoConfigurationTest {
     @Test
     fun contextLoads() {
         contextRunner
-//            .withBean(ReactiveStringRedisTemplate::class.java, { mockk() })
             .withPropertyValues("spring.cloud.cosky.namespace=contextLoads")
             .withUserConfiguration(
                 RedisAutoConfiguration::class.java,

--- a/cosky-spring-cloud-core/src/test/kotlin/me/ahoo/cosky/spring/cloud/support/AppSupportTest.kt
+++ b/cosky-spring-cloud-core/src/test/kotlin/me/ahoo/cosky/spring/cloud/support/AppSupportTest.kt
@@ -2,8 +2,7 @@ package me.ahoo.cosky.spring.cloud.support
 
 import io.mockk.every
 import io.mockk.mockk
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.core.env.Environment
 
@@ -13,6 +12,6 @@ internal class AppSupportTest {
     fun getAppName() {
         val environment = mockk<Environment>()
         every { environment.getProperty("spring.application.name") } returns "appName"
-        assertThat(AppSupport.getAppName(environment), equalTo("appName"))
+        AppSupport.getAppName(environment).assert().isEqualTo("appName")
     }
 }

--- a/cosky-spring-cloud-starter-config/src/test/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfigurationTest.kt
+++ b/cosky-spring-cloud-starter-config/src/test/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfigurationTest.kt
@@ -5,6 +5,7 @@ import me.ahoo.cosky.config.redis.RedisConfigService
 import me.ahoo.cosky.config.redis.RedisConsistencyConfigService
 import me.ahoo.cosky.config.spring.cloud.refresh.CoSkyConfigRefresher
 import me.ahoo.cosky.spring.cloud.CoSkyAutoConfiguration
+import me.ahoo.test.asserts.assert
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
@@ -34,9 +35,9 @@ internal class CoSkyConfigAutoConfigurationTest {
                     .hasSingleBean(CoSkyConfigRefresher::class.java)
                     .getBean(CoSkyConfigProperties::class.java)
                     .extracting {
-                        assertThat(it.enabled).isEqualTo(true)
-                        assertThat(it.configId).isEqualTo("app.yaml")
-                        assertThat(it.timeout).isEqualTo(Duration.ofSeconds(2))
+                        it.enabled.assert().isTrue()
+                        it.configId.assert().isEqualTo("app.yaml")
+                        it.timeout.assert().isEqualTo(Duration.ofSeconds(2))
                     }
             }
     }
@@ -65,9 +66,9 @@ internal class CoSkyConfigAutoConfigurationTest {
                     .hasSingleBean(CoSkyConfigRefresher::class.java)
                     .getBean(CoSkyConfigProperties::class.java)
                     .extracting {
-                        assertThat(it.enabled).isEqualTo(true)
-                        assertThat(it.configId).isEqualTo("test.yaml")
-                        assertThat(it.timeout).isEqualTo(Duration.ofSeconds(3))
+                        it.enabled.assert().isTrue()
+                        it.configId.assert().isEqualTo("test.yaml")
+                        it.timeout.assert().isEqualTo(Duration.ofSeconds(3))
                     }
             }
     }

--- a/cosky-spring-cloud-starter-config/src/test/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyPropertySourceLocatorTest.kt
+++ b/cosky-spring-cloud-starter-config/src/test/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyPropertySourceLocatorTest.kt
@@ -6,8 +6,7 @@ import me.ahoo.cosky.config.ConfigService
 import me.ahoo.cosky.config.redis.RedisConfigService
 import me.ahoo.cosky.core.NamespacedContext
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.boot.origin.OriginTrackedValue
 import reactor.kotlin.test.test
@@ -49,7 +48,7 @@ internal class CoSkyPropertySourceLocatorTest : AbstractReactiveRedisTest() {
         val properties = CoSkyConfigProperties(configId = "${MockIdGenerator.INSTANCE.generateAsString()}.yaml")
         val coSkyPropertySourceLocator = CoSkyPropertySourceLocator(properties, configService)
         val propertySources = coSkyPropertySourceLocator.locate(mockk())
-        assertThat(propertySources, notNullValue())
+        propertySources.assert().isNotNull()
     }
 
     @Test
@@ -61,11 +60,11 @@ internal class CoSkyPropertySourceLocatorTest : AbstractReactiveRedisTest() {
         val properties = CoSkyConfigProperties(configId = "service.yaml")
         val coSkyPropertySourceLocator = CoSkyPropertySourceLocator(properties, configService)
         val propertySources = coSkyPropertySourceLocator.locate(mockk())
-        assertThat(propertySources, notNullValue())
-        assertThat(propertySources.source, isA(Map::class.java))
+        propertySources.assert().isNotNull()
+        propertySources.source.assert().isInstanceOf(Map::class.java)
         @Suppress("UNCHECKED_CAST")
         val source = propertySources.source as Map<String, OriginTrackedValue>
-        assertThat(source["spring.cloud.cosky.discovery.registry.weight"]?.value, `is`(8))
-        assertThat(source["cosid.namespace"]?.value, equalTo("service"))
+        source["spring.cloud.cosky.discovery.registry.weight"]?.value.assert().isEqualTo(8)
+        source["cosid.namespace"]?.value.assert().isEqualTo("service")
     }
 }

--- a/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClientTest.kt
+++ b/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClientTest.kt
@@ -8,8 +8,7 @@ import me.ahoo.cosky.discovery.ServiceInstance.Companion.asServiceInstance
 import me.ahoo.cosky.discovery.redis.RedisServiceDiscovery
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.util.concurrent.ThreadLocalRandom
@@ -27,7 +26,7 @@ internal class CoSkyDiscoveryClientTest : AbstractReactiveRedisTest() {
 
     @Test
     fun description() {
-        assertThat(coSkyDiscoveryClient.description(), `is`("CoSky Discovery Client"))
+        coSkyDiscoveryClient.description().assert().isEqualTo("CoSky Discovery Client")
     }
 
     @Test
@@ -44,17 +43,16 @@ internal class CoSkyDiscoveryClientTest : AbstractReactiveRedisTest() {
             .verifyComplete()
         val instances = coSkyDiscoveryClient.getInstances(instance.serviceId)
             .map { it.instanceId }
-        assertThat(instances, hasItem(instance.instanceId))
+        instances.assert().contains(instance.instanceId)
     }
 
     @Test
     fun getServices() {
-        val services = coSkyDiscoveryClient.services
-        assertThat(services, notNullValue())
+        coSkyDiscoveryClient.services.assert().isNotNull()
     }
 
     @Test
     fun getOrder() {
-        assertThat(coSkyDiscoveryClient.order, `is`(0))
+        coSkyDiscoveryClient.order.assert().isZero()
     }
 }

--- a/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyReactiveDiscoveryClientConfigurationTest.kt
+++ b/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyReactiveDiscoveryClientConfigurationTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.cosky.discovery.spring.cloud.discovery
 
+import me.ahoo.test.asserts.assert
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
@@ -30,7 +31,7 @@ internal class CoSkyReactiveDiscoveryClientConfigurationTest {
                     .extracting {
                         val coSkyReactiveDiscoveryClient =
                             it.discoveryClients.filterIsInstance<CoSkyReactiveDiscoveryClient>().firstOrNull()
-                        assertThat(coSkyReactiveDiscoveryClient).isNotNull
+                        coSkyReactiveDiscoveryClient.assert().isNotNull()
                     }
             }
     }

--- a/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationAutoConfigurationTest.kt
+++ b/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationAutoConfigurationTest.kt
@@ -4,6 +4,7 @@ import me.ahoo.cosky.discovery.RegistryProperties
 import me.ahoo.cosky.discovery.RenewInstanceService
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.discovery.spring.cloud.support.StatusConstants
+import me.ahoo.test.asserts.assert
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
@@ -42,29 +43,29 @@ internal class CoSkyAutoServiceRegistrationAutoConfigurationTest {
                     .hasSingleBean(CoSkyAutoServiceRegistrationOfNoneWeb::class.java)
                     .getBean(CoSkyRegistryProperties::class.java)
                     .extracting {
-                        assertThat(it.serviceId).isEqualTo("")
-                        assertThat(it.schema).isEqualTo("http")
-                        assertThat(it.host).isEqualTo("")
-                        assertThat(it.port).isEqualTo(0)
-                        assertThat(it.weight).isEqualTo(1)
-                        assertThat(it.isEphemeral).isEqualTo(true)
-                        assertThat(it.ttl).isEqualTo(Duration.ofSeconds(60))
-                        assertThat(it.timeout).isEqualTo(Duration.ofSeconds(2))
-                        assertThat(it.metadata).containsKey(StatusConstants.INSTANCE_STATUS_KEY)
-                        assertThat(it.initialStatus).isEqualTo(StatusConstants.STATUS_UP)
-                        assertThat(it.renew).isNotNull()
-                        assertThat(it.renew.initialDelay).isEqualTo(Duration.ofSeconds(1))
-                        assertThat(it.renew.period).isEqualTo(Duration.ofSeconds(10))
+                        it.serviceId.assert().isEqualTo("")
+                        it.schema.assert().isEqualTo("http")
+                        it.host.assert().isEqualTo("")
+                        it.port.assert().isEqualTo(0)
+                        it.weight.assert().isEqualTo(1)
+                        it.isEphemeral.assert().isEqualTo(true)
+                        it.ttl.assert().isEqualTo(Duration.ofSeconds(60))
+                        it.timeout.assert().isEqualTo(Duration.ofSeconds(2))
+                        it.metadata.assert().containsKey(StatusConstants.INSTANCE_STATUS_KEY)
+                        it.initialStatus.assert().isEqualTo(StatusConstants.STATUS_UP)
+                        it.renew.assert().isNotNull()
+                        it.renew.initialDelay.assert().isEqualTo(Duration.ofSeconds(1))
+                        it.renew.period.assert().isEqualTo(Duration.ofSeconds(10))
                     }
                 assertThat(it)
                     .getBean(CoSkyRegistration::class.java)
                     .extracting {
-                        assertThat(it.serviceId).isEqualTo("app")
-                        assertThat(it.scheme).isEqualTo("http")
-                        assertThat(it.host).isNotEmpty()
-                        assertThat(it.port).isEqualTo(0)
-                        assertThat(it.weight).isEqualTo(1)
-                        assertThat(it.isEphemeral).isEqualTo(true)
+                        it.serviceId.assert().isEqualTo("app")
+                        it.scheme.assert().isEqualTo("http")
+                        it.host.assert().isNotEmpty()
+                        it.port.assert().isEqualTo(0)
+                        it.weight.assert().isEqualTo(1)
+                        it.isEphemeral.assert().isTrue()
                     }
             }
     }
@@ -104,29 +105,29 @@ internal class CoSkyAutoServiceRegistrationAutoConfigurationTest {
                     .hasSingleBean(CoSkyAutoServiceRegistrationOfNoneWeb::class.java)
                     .getBean(CoSkyRegistryProperties::class.java)
                     .extracting {
-                        assertThat(it.serviceId).isEqualTo("CustomizeServiceId")
-                        assertThat(it.schema).isEqualTo("https")
-                        assertThat(it.host).isEqualTo("host")
-                        assertThat(it.port).isEqualTo(1024)
-                        assertThat(it.weight).isEqualTo(100)
-                        assertThat(it.isEphemeral).isEqualTo(false)
-                        assertThat(it.ttl).isEqualTo(Duration.ofSeconds(120))
-                        assertThat(it.timeout).isEqualTo(Duration.ofSeconds(2))
-                        assertThat(it.metadata).containsKey("key").containsKey(StatusConstants.INSTANCE_STATUS_KEY)
-                        assertThat(it.initialStatus).isEqualTo("OUT_OF_SERVICE")
-                        assertThat(it.renew).isNotNull()
-                        assertThat(it.renew.initialDelay).isEqualTo(Duration.ofSeconds(2))
-                        assertThat(it.renew.period).isEqualTo(Duration.ofSeconds(10))
+                        it.serviceId.assert().isEqualTo("CustomizeServiceId")
+                        it.schema.assert().isEqualTo("https")
+                        it.host.assert().isEqualTo("host")
+                        it.port.assert().isEqualTo(1024)
+                        it.weight.assert().isEqualTo(100)
+                        it.isEphemeral.assert().isFalse()
+                        it.ttl.assert().isEqualTo(Duration.ofSeconds(120))
+                        it.timeout.assert().isEqualTo(Duration.ofSeconds(2))
+                        it.metadata.assert().containsKey("key").containsKey(StatusConstants.INSTANCE_STATUS_KEY)
+                        it.initialStatus.assert().isEqualTo("OUT_OF_SERVICE")
+                        it.renew.assert().isNotNull()
+                        it.renew.initialDelay.assert().isEqualTo(Duration.ofSeconds(2))
+                        it.renew.period.assert().isEqualTo(Duration.ofSeconds(10))
                     }
                 assertThat(it)
                     .getBean(CoSkyRegistration::class.java)
                     .extracting {
-                        assertThat(it.serviceId).isEqualTo("CustomizeServiceId")
-                        assertThat(it.scheme).isEqualTo("https")
-                        assertThat(it.host).isEqualTo("host")
-                        assertThat(it.port).isEqualTo(1024)
-                        assertThat(it.weight).isEqualTo(100)
-                        assertThat(it.isEphemeral).isEqualTo(false)
+                        it.serviceId.assert().isEqualTo("CustomizeServiceId")
+                        it.scheme.assert().isEqualTo("https")
+                        it.host.assert().isEqualTo("host")
+                        it.port.assert().isEqualTo(1024)
+                        it.weight.assert().isEqualTo(100)
+                        it.isEphemeral.assert().isFalse()
                     }
             }
     }

--- a/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistryTest.kt
+++ b/cosky-spring-cloud-starter-discovery/src/test/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistryTest.kt
@@ -8,8 +8,7 @@ import me.ahoo.cosky.discovery.ServiceDiscovery
 import me.ahoo.cosky.discovery.redis.RedisServiceDiscovery
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
 import me.ahoo.cosky.test.AbstractReactiveRedisTest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Duration
@@ -64,6 +63,6 @@ internal class CoSkyServiceRegistryTest : AbstractReactiveRedisTest() {
         val expectedStatus = "UP"
         coSkyServiceRegistry.setStatus(registration, expectedStatus)
         val actualStatus = coSkyServiceRegistry.getStatus<String>(registration)
-        assertThat(actualStatus, equalTo(expectedStatus))
+        expectedStatus.assert().isEqualTo(actualStatus)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ commons-io = "2.19.0"
 springdoc = "2.8.9"
 junit = "5.13.1"
 fluent-assert = "0.1.2"
-hamcrest = "3.0"
 mockk = "1.14.2"
 jmh = "1.37"
 # plugins
@@ -32,7 +31,6 @@ commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }


### PR DESCRIPTION
- Remove hamcrest dependency from build.gradle.kts and gradle/libs.versions.toml
- Update test assertions across multiple test files to use fluent-assert instead of hamcrest
- Refactor import statements to use me.ahoo.test.asserts.assert instead of org.hamcrest.*