### PR TITLE
build(gradle): reorganize detekt plugin configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,16 @@ allprojects {
         mavenLocal()
         mavenCentral()
     }
+    apply<DetektPlugin>()
+    configure<DetektExtension> {
+        config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
+        buildUponDefaultConfig = true
+        autoCorrect = true
+    }
+    dependencies {
+        detektPlugins(dependenciesProject)
+        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
+    }
     tasks.withType<Jar> {
         manifest {
             attributes["Implementation-Title"] = project.name
@@ -69,12 +79,6 @@ configure(bomProjects) {
 }
 
 configure(libraryProjects) {
-    apply<DetektPlugin>()
-    configure<DetektExtension> {
-        config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
-        buildUponDefaultConfig = true
-        autoCorrect = true
-    }
     apply<DokkaPlugin>()
     apply<JacocoPlugin>()
     apply<JavaLibraryPlugin>()
@@ -145,7 +149,6 @@ configure(libraryProjects) {
     dependencies {
         api(platform(dependenciesProject))
         testImplementation(platform(rootProject.libs.junit.bom))
-        detektPlugins(platform(dependenciesProject))
         jmh(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
@@ -156,7 +159,6 @@ configure(libraryProjects) {
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
         jmh("org.openjdk.jmh:jmh-core")
         jmh("org.openjdk.jmh:jmh-generator-annprocess")
     }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/config/ConfigController.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/config/ConfigController.kt
@@ -128,7 +128,9 @@ class ConfigController(private val configService: ConfigService) {
                             }
                     }
 
-                    else -> return@flatMap IllegalStateException("Unexpected policy[skip,overwrite] value: $importPolicy").toFlux()
+                    else -> return@flatMap IllegalStateException(
+                        "Unexpected policy[skip,overwrite] value: $importPolicy"
+                    ).toFlux()
                 }
             }
             .map { result -> if (result) 1 else 0 }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/configuration/SwaggerConfiguration.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/configuration/SwaggerConfiguration.kt
@@ -29,7 +29,9 @@ import org.springframework.context.annotation.Configuration
 class SwaggerConfiguration {
     val apiInfo: Info = Info()
         .title("CoSky REST API")
-        .description("High-performance, low-cost microservice governance platform. Service Discovery and Configuration Service.")
+        .description(
+            "High-performance, low-cost microservice governance platform. Service Discovery and Configuration Service."
+        )
         .contact(Contact().name("Ahoo Wang").url("https://github.com/Ahoo-Wang/CoSky"))
         .license(License().url("https://github.com/Ahoo-Wang/CoSky/blob/main/LICENSE").name("Apache 2.0"))
         .version(CoSky.VERSION)

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt
@@ -43,6 +43,7 @@ class AuthenticateController(private val tokenCompositeAuthentication: TokenComp
         )
     }
 
+    @Suppress("UnusedParameter")
     @PostMapping("/{username}/refresh")
     fun refresh(
         @PathVariable username: String,

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/RefreshTokenAuthentication.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/RefreshTokenAuthentication.kt
@@ -1,5 +1,6 @@
 package me.ahoo.cosky.rest.security.authentication
 
+import jakarta.validation.constraints.NotBlank
 import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.api.token.TokenPrincipal
 import me.ahoo.cosec.authentication.token.AbstractRefreshTokenAuthentication
@@ -8,13 +9,14 @@ import me.ahoo.cosec.token.TokenVerifier
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
-import jakarta.validation.constraints.NotBlank
 
 @Service
 class RefreshTokenAuthentication(
     private val tokenVerifier: TokenVerifier
 ) :
-    AbstractRefreshTokenAuthentication<DefaultRefreshTokenCredentials, CoSecPrincipal>(DefaultRefreshTokenCredentials::class.java) {
+    AbstractRefreshTokenAuthentication<DefaultRefreshTokenCredentials, CoSecPrincipal>(
+        DefaultRefreshTokenCredentials::class.java
+    ) {
     override val supportCredentials: Class<DefaultRefreshTokenCredentials>
         get() = DefaultRefreshTokenCredentials::class.java
 


### PR DESCRIPTION
- Move Detekt plugin configuration from library projects to the root project
- Remove Detekt-related dependencies from library projects
- Add Detekt plugin and formatting dependency to the root project
- Make minor code adjustments in other files to suppress unused parameter warnings