### PR TITLE
fix(build): correct Kotlin compiler argument syntax

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ configure(libraryProjects) {
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
-            freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all-compatibility")
+            freeCompilerArgs = listOf("-Xjsr305=strict", "-jvm-default=all-compatibility")
             javaParameters = true
         }
     }


### PR DESCRIPTION
- Changed `-Xjvm-default=all-compatibility` to `-jvm-default=all-compatibility`
- Maintained strict JSR-305 nullability checking
- Preserved javaParameters configuration