### PR TITLE
fix(config): update favicon path in security policy

### DIFF
--- a/cosky-rest-api/src/main/resources/cosky-policy.json
+++ b/cosky-rest-api/src/main/resources/cosky-policy.json
@@ -37,7 +37,7 @@
             "/",
             "/index.html",
             "/assets/**",
-            "/favicon.ico",
+            "/favicon.svg",
             "/login",
             "/home",
             "/config",


### PR DESCRIPTION
- Changed favicon path from .ico to .svg format in cosky-policy.json
- Updated security whitelist to include favicon.svg instead of favicon.ico