### PR TITLE
ci(renovate): optimize config and harden self-hosted workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,12 +14,15 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 1'
   workflow_dispatch:
 
 concurrency:
   group: renovate
   cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   renovate:
@@ -27,15 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46.1.15
+        # yamllint disable-line rule:line-length
+        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd  # v46.1.15
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          LOG_LEVEL: debug
+          LOG_LEVEL: info
           RENOVATE_REPOSITORIES: Ahoo-Wang/CoSky
           RENOVATE_ONBOARDING: 'false'
           RENOVATE_PLATFORM: github

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":semanticCommits", ":dependencyDashboard", ":enableVulnerabilityAlertsWithLabel(security)"],
   "timezone": "Asia/Shanghai",
+  "schedule": ["after 9am and before 11am every weekday"],
   "labels": ["dependencies"],
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
-  "rangeStrategy": "bump",
-  "lockFileMaintenance": { "enabled": false },
+  "rangeStrategy": "auto",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on Monday"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  },
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": " Dependency Updates",
   "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "branchConcurrentLimit": 5,
+  "separateMajorMinor": true,
+  "major": {
+    "labels": ["dependencies", "major"],
+    "dependencyDashboardApproval": true
+  },
   "packageRules": [
     {
       "description": "Group Spring ecosystem updates into a single PR",
@@ -18,6 +36,37 @@
       "description": "Group Kotlin-related updates into a single PR",
       "matchPackagePatterns": ["^org\\.jetbrains\\.kotlin"],
       "groupName": "kotlin"
+    },
+    {
+      "description": "Group Ahoo ecosystem libraries (cosid/simba/cosec/fluent-assert) that release in lockstep",
+      "matchPackagePatterns": ["^me\\.ahoo\\."],
+      "groupName": "ahoo-ecosystem"
+    },
+    {
+      "description": "Group testing and build tooling",
+      "matchPackageNames": ["io.mockk:mockk", "org.openjdk.jmh:jmh-core", "org.openjdk.jmh:jmh-generator-annprocess"],
+      "matchPackagePatterns": ["^io\\.gitlab\\.arturbosch\\.detekt", "^org\\.jetbrains\\.dokka", "^org\\.junit"],
+      "groupName": "test-and-build-tooling"
+    },
+    {
+      "description": "Let Renovate keep its own GitHub Action version up to date",
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["renovatebot/github-action"],
+      "schedule": ["before 6am on Monday"]
+    },
+    {
+      "description": "Pin GitHub Actions to a digest for supply-chain safety",
+      "matchDepTypes": ["action"],
+      "pinDigests": true
+    },
+    {
+      "description": "Auto-merge safe patch-level updates for dev/build tooling after CI passes",
+      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["io.mockk:mockk"],
+      "matchPackagePatterns": ["^io\\.gitlab\\.arturbosch\\.detekt", "^org\\.jetbrains\\.dokka"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Optimizes the Renovate configuration and hardens the self-hosted workflow based on dependency-management best practices.

### `renovate.json`

| Area | Change | Why |
|------|--------|-----|
| Range strategy | `bump` → `auto` | Correct for `libs.versions.toml` version-catalog refs |
| Schedule | Daily → batched weekday 9–11am + lockFileMaintenance Monday before 6am | Reduces PR noise / CI cost |
| Major versions | `separateMajorMinor: true` + `major:{labels, dependencyDashboardApproval}` | Major bumps (e.g. Spring Boot 4→5) get isolated PRs requiring approval |
| Vulnerability alerts | Enabled (security label, bypasses schedule) | Open PRs immediately on CVE |
| Dependency dashboard | Enabled | Track all pending updates in one issue |
| Grouping | + `me.ahoo.*` ecosystem, test/build tooling | Lockstep-released libs grouped together |
| Self-hosted action | Now self-managed by Renovate | Removes stale manual pin |
| Action digest pinning | `pinDigests: true` for `action` deps | Supply-chain safety |
| Rate limiting | `prHourlyLimit: 2`, `branchConcurrentLimit: 5` | Avoid PR floods |
| Auto-merge | Patch updates for detekt/dokka/mockk after CI | Low-risk tooling stays current |

### `.github/workflows/renovate.yml`

- **Digest-pin** `actions/checkout` (1af3b93, v6.0.0) and `renovatebot/github-action` (8217b3fc, v46.1.15)
- **`LOG_LEVEL: debug` → `info`** — debug logs can leak repo data/secrets in CI logs
- **Daily cron → weekly Monday** (`0 2 * * 1`) matching batched cadence
- **`permissions: { contents: read }`** — least privilege for checkout

### Notes

- No changes to Lua scripts, Redis key schema, or the consistency layer.
- Follow-up: ensure `RENOVATE_TOKEN` retains `contents:write` + `pull-requests:write` (the repo-level `permissions:` block only restricts the checkout step, not the token scope).