### PR TITLE
fix(deps): update cosid to 3.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # libraries
 spring-boot = "4.0.5"
 spring-cloud = "2025.1.1"
-cosid = "3.0.5"
+cosid = "3.2.0"
 simba = "3.0.1"
 cosec = "4.3.4"
 guava = "33.5.0-jre"


### PR DESCRIPTION
Bumps `cosid` from `3.0.5` to `3.2.0`.

### Changes
- `gradle/libs.versions.toml`: `cosid` = `3.0.5` → `3.2.0`

This is the single source of truth for the version (managed via `cosid-bom`); all modules reference it through `version.ref`.

### Verification
- Dependency tree confirms all `me.ahoo.cosid:*` artifacts resolve to `3.2.0` (transitive `3.0.x` lifted to `3.2.0`).