### PR TITLE
fix(deps): restore overrides in dashboard lockfile

### DIFF
--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: ^3.4.11
+  js-yaml: ^4.2.0
+
 importers:
 
   .:
@@ -1339,8 +1343,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   electron-to-chromium@1.5.353:
     resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
@@ -3255,7 +3259,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3566,7 +3570,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.11
       marked: 14.0.0
 
   ms@2.1.3: {}


### PR DESCRIPTION
### Problem
The `@babel/core` upgrade (#930) regenerated `dashboard/pnpm-lock.yaml` and **dropped the `overrides` block** (dompurify / js-yaml). This broke `pnpm install --frozen-lockfile` (used in the Docker build) with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

Consequently **main's Docker Image Deploy has been failing** since #930 was merged.

### Fix
Regenerate the lockfile with `pnpm install --no-frozen-lockfile` so it matches `package.json`:
- restores the `overrides` block (dompurify `^3.4.11`, js-yaml `^4.2.0`)
- resolves `dompurify` to `3.4.11` (the intended override) instead of `3.2.7`

### Verification
```
$ pnpm install --frozen-lockfile   # ✅ passes
Lockfile is up to date, resolution step is skipped
```

This is a lockfile-only change; `package.json` is untouched.