### PR TITLE
ci(renovate): raise limits and unblock core deps

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,7 @@ concurrency:
 
 permissions:
   contents: read
+  security-events: read
 
 jobs:
   renovate:

--- a/renovate.json
+++ b/renovate.json
@@ -18,9 +18,9 @@
   },
   "dependencyDashboard": true,
   "dependencyDashboardTitle": " Dependency Updates",
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
-  "branchConcurrentLimit": 5,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 10,
+  "branchConcurrentLimit": 20,
   "separateMajorMinor": true,
   "major": {
     "labels": ["dependencies", "major"],
@@ -30,12 +30,14 @@
     {
       "description": "Group Spring ecosystem updates into a single PR",
       "matchPackagePatterns": ["^org\\.springframework"],
-      "groupName": "spring"
+      "groupName": "spring",
+      "prPriority": 10
     },
     {
       "description": "Group Kotlin-related updates into a single PR",
       "matchPackagePatterns": ["^org\\.jetbrains\\.kotlin"],
-      "groupName": "kotlin"
+      "groupName": "kotlin",
+      "prPriority": 10
     },
     {
       "description": "Group Ahoo ecosystem libraries (Maven me.ahoo.* + npm @ahoo-wang/*) that release in lockstep",


### PR DESCRIPTION
### Problem
Renovate runs successfully but **Spring/Kotlin updates never land as PRs** — they are stuck behind the rate limits. The [Dependency Dashboard (#931)](../issues/931) lists them under **Rate-Limited**:

> - `renovate/spring` — Update spring (`spring-cloud-dependencies`, `spring-boot-dependencies`)
> - `renovate/kotlin` — Update kotlin

Root cause: `prConcurrentLimit=5` + `prHourlyLimit=2` + many queued branches mean each run only creates ~2 PRs, and core deps lose the race. Renovate itself is healthy.

The dashboard also reports:
> ⚠️ `Cannot access vulnerability alerts. Please ensure permissions have been granted.`

### Fix
**`renovate.json`**
- `prConcurrentLimit`: 5 → 20
- `branchConcurrentLimit`: 5 → 20
- `prHourlyLimit`: 2 → 10
- Add `prPriority: 10` to the `spring` and `kotlin` groups so core ecosystem updates are created ahead of lower-priority tooling updates.

**`.github/workflows/renovate.yml`**
- Grant `security-events: read` so Renovate can read vulnerability alerts (clears the dashboard warning and enables security-driven PRs).

### After merge
Manually trigger the Renovate workflow (or wait for the next run); the `renovate/spring` branch + PR will be created automatically. No further dashboard checkbox needed since the limits are lifted.