### PR TITLE
fix(renovate): preserve pnpm overrides in lockfile updates

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -57,5 +57,6 @@
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
-  }
+  },
+  "packageManager": "pnpm@10.33.0"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
   "rangeStrategy": "auto",
+  "postUpdateOptions": ["pnpmDedupe"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am on Monday"]


### PR DESCRIPTION
### Problem
Renovate-generated PRs touching `dashboard/pnpm-lock.yaml` (#934, #939, #940, #944) **drop the `pnpm.overrides` block** (dompurify / js-yaml) and downgrade `dompurify` 3.4.11 → 3.2.7. Merging any of them breaks `pnpm install --frozen-lockfile` in Docker builds with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — the same regression fixed in #932.

### Root cause
`dashboard/package.json` had **no `packageManager` field**, so Renovate could not pin the pnpm version and fell back to its own lockfile-update logic, which bypasses pnpm's `overrides` handling.

### Fix
**`dashboard/package.json`** — add `"packageManager": "pnpm@10.33.0"` so Renovate (and the whole toolchain) resolve the lockfile with the real pnpm version, preserving `overrides`.

**`renovate.json`** — enable `postUpdateOptions: ["pnpmDedupe"]` so Renovate runs pnpm after dependency updates instead of hand-editing the lockfile.

### Verification
```
$ pnpm install --frozen-lockfile   # ✅ passes, overrides intact
Lockfile is up to date, resolution step is skipped
```

### After merge
The 4 blocked PRs (#934/#939/#940/#944) should be closed so Renovate regenerates them correctly against this fix.