### PR TITLE
Improve dashboard navigation search

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -259,10 +259,15 @@
 .app-command-search input {
   height: 40px;
   padding-left: 38px;
-  padding-right: 42px;
+  padding-right: 66px;
   border-color: rgba(255, 255, 255, .12);
   background: rgba(255, 255, 255, .06);
   color: white;
+}
+
+.app-command-search input:focus-visible {
+  border-color: rgba(139, 124, 246, .7);
+  box-shadow: 0 0 0 2px rgba(124, 102, 238, .2);
 }
 
 .app-command-search input::placeholder {
@@ -280,6 +285,170 @@
 .app-command-search-submit:hover {
   background: rgba(255, 255, 255, .08) !important;
   color: white !important;
+}
+
+.app-command-shortcut {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 6px;
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, .06);
+  color: #aaaabd;
+  font-family: inherit;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.app-command-results {
+  position: absolute;
+  z-index: 60;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: 12px;
+  background: #191930;
+  box-shadow: 0 18px 48px rgba(7, 7, 20, .38);
+}
+
+.app-command-results-header,
+.app-command-results-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #9292a6;
+  font-size: 11px;
+}
+
+.app-command-results-header {
+  padding: 9px 10px 7px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.app-command-result {
+  display: flex;
+  width: calc(100% - 8px);
+  min-height: 52px;
+  align-items: center;
+  gap: 10px;
+  margin: 0 4px;
+  border: 0;
+  border-radius: 8px;
+  padding: 7px 9px;
+  background: transparent;
+  color: #dadae7;
+  text-align: left;
+  cursor: pointer;
+}
+
+.app-command-result[aria-selected='true'] {
+  background: rgba(124, 102, 238, .18);
+  color: white;
+}
+
+.app-command-result-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: none;
+  place-items: center;
+  border: 1px solid rgba(139, 124, 246, .2);
+  border-radius: 8px;
+  background: rgba(124, 102, 238, .1);
+  color: #9c8df8;
+}
+
+.app-command-result-icon svg,
+.app-command-result > svg {
+  width: 16px;
+  height: 16px;
+}
+
+.app-command-result > svg {
+  color: #77778d;
+}
+
+.app-command-result-copy {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 2px;
+}
+
+.app-command-result-copy strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.app-command-result-copy small {
+  overflow: hidden;
+  color: #9292a6;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-command-result-current {
+  border-radius: 999px;
+  padding: 3px 7px;
+  background: rgba(255, 255, 255, .08);
+  color: #b7b7c8;
+  font-size: 10px;
+}
+
+.app-command-empty {
+  display: grid;
+  min-height: 112px;
+  place-items: center;
+  align-content: center;
+  gap: 4px;
+  color: #dadae7;
+}
+
+.app-command-empty svg {
+  width: 20px;
+  margin-bottom: 3px;
+  color: #77778d;
+}
+
+.app-command-empty strong {
+  font-size: 13px;
+}
+
+.app-command-empty span {
+  color: #9292a6;
+  font-size: 11px;
+}
+
+.app-command-results-footer {
+  justify-content: flex-start;
+  gap: 14px;
+  margin-top: 5px;
+  padding: 8px 10px;
+  border-top: 1px solid rgba(255, 255, 255, .08);
+}
+
+.app-command-results-footer span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.app-command-results-footer kbd {
+  min-width: 18px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: 4px;
+  padding: 1px 4px;
+  background: rgba(255, 255, 255, .06);
+  color: #c7c7d4;
+  font-family: inherit;
+  font-size: 9px;
+  text-align: center;
 }
 
 .app-icon-link {

--- a/dashboard/src/components/layout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout.tsx
@@ -91,7 +91,7 @@ export const AuthenticatedLayout = () => {
 
     useEffect(() => {
         const focusSearch = (event: globalThis.KeyboardEvent) => {
-            if (event.key !== '/' && event.code !== 'Slash') return;
+            if (event.key !== '/') return;
             if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
             event.preventDefault();
             searchInputRef.current?.focus();
@@ -155,7 +155,7 @@ export const AuthenticatedLayout = () => {
     };
 
     const handleLayoutKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-        if (event.key !== '/' && event.code !== 'Slash') return;
+        if (event.key !== '/') return;
         if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
         event.preventDefault();
         event.stopPropagation();

--- a/dashboard/src/components/layout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout.tsx
@@ -11,8 +11,8 @@
  * limitations under the License.
  */
 
-import {useState} from 'react';
-import type {FormEvent} from 'react';
+import {useEffect, useRef, useState} from 'react';
+import type {FocusEvent, FormEvent, KeyboardEvent} from 'react';
 import {
     ArrowRight,
     ChevronDown,
@@ -56,16 +56,16 @@ import {toast} from 'sonner';
 import {GiteeIcon, GitHubIcon} from '@/components/icons/repository-icons';
 
 const primaryItems = [
-    {to: '/home', label: 'Dashboard', icon: LayoutDashboard},
-    {to: '/config', label: 'Configuration', icon: FileText},
-    {to: '/service', label: 'Service', icon: Cloud},
-    {to: '/namespace', label: 'Namespace', icon: Network},
+    {to: '/home', label: 'Dashboard', description: 'System health and topology', icon: LayoutDashboard},
+    {to: '/config', label: 'Configuration', description: 'Manage configuration files', icon: FileText},
+    {to: '/service', label: 'Service', description: 'Services and instances', icon: Cloud},
+    {to: '/namespace', label: 'Namespace', description: 'Isolation boundaries', icon: Network},
 ];
 
 const securityItems = [
-    {to: '/user', label: 'User', icon: User},
-    {to: '/role', label: 'Role', icon: ShieldCheck},
-    {to: '/audit-log', label: 'Audit Log', icon: FileText},
+    {to: '/user', label: 'User', description: 'Accounts and role assignments', icon: User},
+    {to: '/role', label: 'Role', description: 'Access policies', icon: ShieldCheck},
+    {to: '/audit-log', label: 'Audit Log', description: 'Security and operation history', icon: FileText},
 ];
 
 const searchTargets = [...primaryItems, ...securityItems];
@@ -73,13 +73,33 @@ const searchTargets = [...primaryItems, ...securityItems];
 export const AuthenticatedLayout = () => {
     const [collapsed, setCollapsed] = useLayoutCollapsed();
     const [searchValue, setSearchValue] = useState('');
+    const [searchOpen, setSearchOpen] = useState(false);
+    const [activeSearchIndex, setActiveSearchIndex] = useState(0);
     const [mobileOpen, setMobileOpen] = useState(false);
+    const searchInputRef = useRef<HTMLInputElement>(null);
     const {currentUser, signOut} = useSecurityContext();
     const navigate = useNavigate();
     const location = useLocation();
     const {openDrawer, closeDrawer} = useDrawer();
     const apiOrigin = new URL(import.meta.env.VITE_API_BASE_URL || window.location.origin, window.location.origin).origin;
     const environmentName = import.meta.env.VITE_ENVIRONMENT_NAME?.trim() || new URL(apiOrigin).host;
+    const searchQuery = searchValue.trim().toLowerCase();
+    const filteredSearchTargets = searchTargets.filter(item =>
+        `${item.label} ${item.description}`.toLowerCase().includes(searchQuery)
+    );
+    const commandShortcut = '/';
+
+    useEffect(() => {
+        const focusSearch = (event: globalThis.KeyboardEvent) => {
+            if (event.key !== '/' && event.code !== 'Slash') return;
+            if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
+            event.preventDefault();
+            searchInputRef.current?.focus();
+            setSearchOpen(true);
+        };
+        window.addEventListener('keydown', focusSearch);
+        return () => window.removeEventListener('keydown', focusSearch);
+    }, []);
 
     const handleChangePwd = () => {
         openDrawer(
@@ -91,21 +111,64 @@ export const AuthenticatedLayout = () => {
         );
     };
 
+    const navigateToSearchTarget = (target: (typeof searchTargets)[number]) => {
+        navigate(target.to);
+        setSearchValue('');
+        setSearchOpen(false);
+        searchInputRef.current?.blur();
+    };
+
     const handleSearch = (event: FormEvent) => {
         event.preventDefault();
-        const query = searchValue.trim().toLowerCase();
-        if (!query) return;
-        const target = searchTargets.find(item => item.label.toLowerCase().includes(query));
+        const target = filteredSearchTargets[activeSearchIndex];
         if (target) {
-            navigate(target.to);
-            setSearchValue('');
+            navigateToSearchTarget(target);
             return;
         }
         toast.error(`No page matches “${searchValue.trim()}”.`);
     };
 
+    const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.currentTarget.form?.requestSubmit();
+            return;
+        }
+        if (event.key === 'Escape') {
+            setSearchOpen(false);
+            return;
+        }
+        if (!['ArrowDown', 'ArrowUp'].includes(event.key) || filteredSearchTargets.length === 0) return;
+        event.preventDefault();
+        setSearchOpen(true);
+        setActiveSearchIndex(index =>
+            event.key === 'ArrowDown'
+                ? (index + 1) % filteredSearchTargets.length
+                : (index - 1 + filteredSearchTargets.length) % filteredSearchTargets.length
+        );
+    };
+
+    const handleSearchFocus = () => {
+        const nextIndex = filteredSearchTargets.findIndex(item => item.to !== location.pathname);
+        setActiveSearchIndex(nextIndex >= 0 ? nextIndex : 0);
+        setSearchOpen(true);
+    };
+
+    const handleLayoutKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key !== '/' && event.code !== 'Slash') return;
+        if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
+        event.preventDefault();
+        event.stopPropagation();
+        searchInputRef.current?.focus();
+        setSearchOpen(true);
+    };
+
+    const handleSearchBlur = (event: FocusEvent<HTMLFormElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setSearchOpen(false);
+    };
+
     return (
-        <div className={cn('app-shell', collapsed && 'app-shell-collapsed', mobileOpen && 'app-mobile-open')}>
+        <div className={cn('app-shell', collapsed && 'app-shell-collapsed', mobileOpen && 'app-mobile-open')} onKeyDownCapture={handleLayoutKeyDown}>
             <aside className="app-sidebar">
                 <NavLink to="/home" className="app-brand" onClick={() => setMobileOpen(false)}>
                     <img src={CoskyLogo} alt="CoSky"/>
@@ -160,18 +223,70 @@ export const AuthenticatedLayout = () => {
                         </Button>
                         <CurrentNamespaceSelector/>
                     </div>
-                    <form className="app-command-search" role="search" onSubmit={handleSearch}>
+                    <form className="app-command-search" role="search" onSubmit={handleSearch} onBlur={handleSearchBlur}>
                         <Search/>
                         <Input
-                            type="search"
+                            ref={searchInputRef}
+                            type="text"
+                            role="combobox"
                             value={searchValue}
-                            onChange={event => setSearchValue(event.target.value)}
-                            placeholder="Go to Dashboard, Configuration, Service..."
+                            onChange={event => {
+                                setSearchValue(event.target.value);
+                                setActiveSearchIndex(0);
+                                setSearchOpen(true);
+                            }}
+                            onFocus={handleSearchFocus}
+                            onKeyDown={handleSearchKeyDown}
+                            placeholder="Search pages..."
                             aria-label="Search navigation"
+                            aria-expanded={searchOpen}
+                            aria-controls="navigation-search-results"
+                            aria-autocomplete="list"
+                            aria-activedescendant={searchOpen && filteredSearchTargets.length > 0 ? `navigation-search-result-${activeSearchIndex}` : undefined}
                         />
-                        <Button type="submit" variant="ghost" size="icon-sm" className="app-command-search-submit" aria-label="Go to page">
-                            <ArrowRight/>
-                        </Button>
+                        {searchValue ? (
+                            <Button type="submit" variant="ghost" size="icon-sm" className="app-command-search-submit" aria-label="Open selected page">
+                                <ArrowRight/>
+                            </Button>
+                        ) : <kbd className="app-command-shortcut">{commandShortcut}</kbd>}
+                        {searchOpen && (
+                            <div id="navigation-search-results" className="app-command-results" role="listbox" aria-label="Navigation results">
+                                <div className="app-command-results-header">
+                                    <span>{searchQuery ? 'Matching pages' : 'Quick navigation'}</span>
+                                    <small>{filteredSearchTargets.length} result{filteredSearchTargets.length === 1 ? '' : 's'}</small>
+                                </div>
+                                {filteredSearchTargets.map((item, index) => {
+                                    const Icon = item.icon;
+                                    const isCurrent = location.pathname === item.to;
+                                    return <button
+                                        key={item.to}
+                                        id={`navigation-search-result-${index}`}
+                                        type="button"
+                                        role="option"
+                                        aria-selected={index === activeSearchIndex}
+                                        className="app-command-result"
+                                        onMouseEnter={() => setActiveSearchIndex(index)}
+                                        onClick={() => navigateToSearchTarget(item)}
+                                    >
+                                        <span className="app-command-result-icon"><Icon/></span>
+                                        <span className="app-command-result-copy"><strong>{item.label}</strong><small>{item.description}</small></span>
+                                        {isCurrent ? <span className="app-command-result-current">Current</span> : <ArrowRight/>}
+                                    </button>;
+                                })}
+                                {filteredSearchTargets.length === 0 && (
+                                    <div className="app-command-empty" role="status">
+                                        <Search/>
+                                        <strong>No pages found</strong>
+                                        <span>Try “service”, “user”, or “audit”.</span>
+                                    </div>
+                                )}
+                                <div className="app-command-results-footer">
+                                    <span><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>
+                                    <span><kbd>Enter</kbd> Open</span>
+                                    <span><kbd>Esc</kbd> Close</span>
+                                </div>
+                            </div>
+                        )}
                     </form>
                     <div className="app-header-actions">
                         <span className="app-environment" title={`Connected to ${apiOrigin}`}>

--- a/dashboard/tests/ui/dashboard.spec.ts
+++ b/dashboard/tests/ui/dashboard.spec.ts
@@ -478,12 +478,28 @@ test('route guards, command search, password visibility, and form validation sta
     await page.getByRole('button', {name: 'Hide password'}).click();
     await login(page);
 
-    const commandSearch = page.getByRole('searchbox', {name: 'Search navigation'});
+    const commandSearch = page.getByRole('combobox', {name: 'Search navigation'});
+    await expect(commandSearch).toBeVisible();
+    await page.keyboard.press('/');
+    await expect(commandSearch).toBeFocused();
+    await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeVisible();
+    await expect(page.getByRole('option', {name: /Configuration/})).toHaveAttribute('aria-selected', 'true');
+    await commandSearch.press('Enter');
+    await expect(page).toHaveURL(/\/config$/);
+    await page.keyboard.press('/');
+    await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeVisible();
+    await commandSearch.press('Escape');
+    await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeHidden();
+    await commandSearch.fill('service');
+    await expect(page.getByRole('option', {name: /Service/})).toBeVisible();
+    await commandSearch.press('Enter');
+    await expect(page).toHaveURL(/\/service$/);
     await commandSearch.fill('configuration');
     await commandSearch.press('Enter');
     await expect(page).toHaveURL(/\/config$/);
     await commandSearch.fill('missing-page');
-    await page.getByRole('button', {name: 'Go to page'}).click();
+    await expect(page.getByText('No pages found')).toBeVisible();
+    await page.getByRole('button', {name: 'Open selected page'}).click();
     await expect(page.getByText('No page matches “missing-page”.')).toBeVisible();
 
     await page.getByRole('button', {name: 'Import', exact: true}).click();

--- a/dashboard/tests/ui/dashboard.spec.ts
+++ b/dashboard/tests/ui/dashboard.spec.ts
@@ -480,6 +480,9 @@ test('route guards, command search, password visibility, and form validation sta
 
     const commandSearch = page.getByRole('combobox', {name: 'Search navigation'});
     await expect(commandSearch).toBeVisible();
+    await page.keyboard.press('?');
+    await expect(commandSearch).not.toBeFocused();
+    await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeHidden();
     await page.keyboard.press('/');
     await expect(commandSearch).toBeFocused();
     await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeVisible();


### PR DESCRIPTION
## What changed

- Replace the header's single-result search with an accessible command menu.
- Add page descriptions, filtered results, current-page context, empty states, and keyboard navigation.
- Support `/`, arrow keys, `Enter`, and `Escape` consistently, including the in-app browser event path.
- Add E2E coverage for shortcut focus, empty-query navigation, filtered navigation, and no-result feedback.

## Why

The previous search gave little feedback and keyboard actions could appear unresponsive. Empty-query `Enter` was explicitly ignored, the current page could remain selected, and shortcut events did not cover every browser event path.

## Impact

Desktop users can quickly discover and open dashboard pages with either the mouse or keyboard. The interaction now exposes clear selection and no-result feedback while preserving form inputs elsewhere in the application.

## Validation

- `pnpm lint`
- `pnpm build`
- `pnpm exec playwright test tests/ui/dashboard.spec.ts --grep "route guards, command search"`
- Manual verification against the running dashboard: `/` opens the menu and `Enter` navigates to the selected page.
