### PR TITLE
Stabilize dashboard loading E2E test

### DIFF
--- a/dashboard/tests/ui/dashboard.spec.ts
+++ b/dashboard/tests/ui/dashboard.spec.ts
@@ -421,8 +421,10 @@ test('tables expose loading, empty, sorting, pagination, and server-error states
 
     api.manyServices = true;
     api.delayNext = {method: 'GET', path: /\/services\/stats$/, milliseconds: 800};
-    await page.getByRole('link', {name: 'Service', exact: true}).click();
-    await expect(page.locator('[data-slot="skeleton"]').first()).toBeVisible();
+    await Promise.all([
+        expect(page.locator('[data-slot="skeleton"]').first()).toBeVisible(),
+        page.getByRole('link', {name: 'Service', exact: true}).click(),
+    ]);
     await expect(page.getByText('api-gateway', {exact: true})).toBeVisible();
     await page.getByRole('button', {name: 'Next page'}).click();
     await expect(page.getByText('2 / 2')).toBeVisible();


### PR DESCRIPTION
## What changed

Run the Service navigation and loading-skeleton assertion concurrently so Playwright observes the transient loading state while the delayed API request is active.

## Root cause

The test awaited the navigation click before checking the skeleton. Playwright's click auto-wait could consume the 800 ms mocked loading window, so CI intermittently searched for the skeleton after it had already disappeared.

This caused the Docker Image Deploy failures in [run 32129618524](https://github.com/Ahoo-Wang/CoSky/actions/runs/32129618524/job/95692266147) and the earlier push/tag runs.

## Validation

- target E2E repeated 10 times with CI-equivalent 2-worker concurrency: 10 passed
- `pnpm test:coverage`: 10 passed
- coverage: 90.58% statements, 87.72% branches, 84.23% functions, 92.44% lines
- `pnpm lint`
