### PR TITLE
Fix fixed instance TTL

### DIFF
--- a/cosky-discovery/src/main/resources/registry_register.lua
+++ b/cosky-discovery/src/main/resources/registry_register.lua
@@ -43,4 +43,5 @@ redis.call("publish", instanceKey, "register");
 if not fixed then
     return redis.call("expire", instanceKey, instanceTtl);
 end
+redis.call("persist", instanceKey);
 return 1;

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceRegistryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceRegistryTest.kt
@@ -140,6 +140,10 @@ class RedisServiceRegistryTest : AbstractReactiveRedisTest() {
 
         serviceRegistry.register(namespace, ephemeralInstance.withIsEphemeral(false)).block()
         serviceRegistry.registeredEphemeralInstances.containsKey(namespacedInstanceId).assert().isFalse()
+        serviceDiscovery.getInstanceTtl(namespace, ephemeralInstance.serviceId, ephemeralInstance.instanceId)
+            .test()
+            .expectNext(ServiceInstance.TTL_AT_FOREVER)
+            .verifyComplete()
     }
 
     @Test


### PR DESCRIPTION
## What changed

- persist an existing Redis instance key when re-registering it as non-ephemeral
- verify the converted instance reports `TTL_AT_FOREVER`

## Why

Re-registering an ephemeral instance as fixed removed it from the renewal set but left the previous Redis TTL intact, so the supposedly fixed instance still expired.

## Validation

- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.RedisServiceRegistryTest`
- `./gradlew :cosky-discovery:test :cosky-discovery:detekt`
- `git diff --check`