### PR TITLE
Fix rollback of removed config

### DIFF
--- a/cosky-config/src/main/resources/config_rollback.lua
+++ b/cosky-config/src/main/resources/config_rollback.lua
@@ -47,11 +47,16 @@ local currentHash = redis.call("hget", configKey, hashField)
 if (currentHash ~= nil) and (currentHash == targetHash) then
     return 0;
 end
-redis.call("sadd", configIdxKey, configKey, configKey)
-
 local currentVersion = redis.call("hget", configKey, versionField)
-local nextVersion = currentVersion + 1;
-addHistory(currentVersion, configKey, op)
+local nextVersion;
+if currentVersion then
+    nextVersion = currentVersion + 1;
+    addHistory(currentVersion, configKey, op)
+else
+    local lastHistoryVersion = redis.call('zrevrange', configHistoryIdxKey, 0, 0, 'WITHSCORES')
+    nextVersion = lastHistoryVersion[2] + 1;
+end
+redis.call("sadd", configIdxKey, configKey)
 local data = targetHistoryConfig["data"];
 local createTime = redis.call('time')[1];
 

--- a/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/RedisConfigServiceTest.kt
+++ b/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/RedisConfigServiceTest.kt
@@ -12,7 +12,11 @@
  */
 package me.ahoo.cosky.config.redis
 
+import me.ahoo.cosid.test.MockIdGenerator
 import me.ahoo.cosky.config.ConfigService
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
 
 /**
  * @author ahoo wang
@@ -21,5 +25,27 @@ class RedisConfigServiceTest : ConfigServiceSpec() {
 
     override fun createConfigService(): ConfigService {
         return RedisConfigService(redisTemplate)
+    }
+
+    @Test
+    fun rollbackRemovedConfig() {
+        val namespace = MockIdGenerator.INSTANCE.generateAsString()
+        val configId = MockIdGenerator.INSTANCE.generateAsString()
+        val version1Data = "version-1"
+        configService.setConfig(namespace, configId, version1Data)
+            .then(configService.setConfig(namespace, configId, "version-2"))
+            .then(configService.removeConfig(namespace, configId))
+            .then(configService.rollback(namespace, configId, 1))
+            .test()
+            .expectNext(true)
+            .verifyComplete()
+        configService.getConfig(namespace, configId)
+            .test()
+            .expectNextMatches {
+                it.data.assert().isEqualTo(version1Data)
+                it.version.assert().isEqualTo(3)
+                true
+            }
+            .verifyComplete()
     }
 }


### PR DESCRIPTION
## What changed

- derive the next version from the history index when the active config no longer exists
- restore the config index only after version calculation succeeds
- cover set, update, remove, and rollback as one Redis integration path

## Why

Removing a config archives the current version and deletes the active hash. Rolling it back then attempted arithmetic on a missing `currentVersion`, failed, and left a dangling config index entry.

## Validation

- `./gradlew :cosky-config:test --tests me.ahoo.cosky.config.redis.RedisConfigServiceTest.rollbackRemovedConfig`
- `./gradlew :cosky-config:test :cosky-config:detekt`
- `git diff --check`