### PR TITLE
Fix empty metadata update

### DIFF
--- a/cosky-discovery/src/main/resources/registry_set_metadata.lua
+++ b/cosky-discovery/src/main/resources/registry_set_metadata.lua
@@ -15,7 +15,8 @@ if #instanceKeys > 0 then
     end
 end
 
-redis.call("hmset", instanceKey, unpack(ARGV, 2, #ARGV));
+if #ARGV > 1 then
+    redis.call("hmset", instanceKey, unpack(ARGV, 2, #ARGV));
+end
 redis.call("publish", instanceKey, "set_metadata");
 return 1;
-

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceRegistryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceRegistryTest.kt
@@ -108,6 +108,20 @@ class RedisServiceRegistryTest : AbstractReactiveRedisTest() {
     }
 
     @Test
+    fun clearMetadata() {
+        val instance = randomInstance()
+        serviceRegistry.register(namespace, instance)
+            .then(serviceRegistry.setMetadata(namespace, instance.serviceId, instance.instanceId, emptyMap()))
+            .test()
+            .expectNext(true)
+            .verifyComplete()
+        serviceDiscovery.getInstance(namespace, instance.serviceId, instance.instanceId)
+            .test()
+            .expectNextMatches { it.metadata.isEmpty() }
+            .verifyComplete()
+    }
+
+    @Test
     fun renew() {
         serviceRegistry.renew(namespace, randomInstance())
             .test()


### PR DESCRIPTION
## What changed

- skip `HMSET` when a metadata replacement contains no fields
- keep the existing cleanup and `set_metadata` publication behavior
- verify an empty map clears user metadata and completes successfully

## Why

The script deleted existing metadata and then invoked `HMSET` without field/value arguments. Redis returned an error after the deletion, leaving a partial mutation.

## Validation

- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.RedisServiceRegistryTest.clearMetadata`
- `./gradlew :cosky-discovery:test :cosky-discovery:detekt`
- `git diff --check`