### PR TITLE
Fix zero weight selection

### DIFF
--- a/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/loadbalancer/BinaryWeightRandomLoadBalancer.kt
+++ b/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/loadbalancer/BinaryWeightRandomLoadBalancer.kt
@@ -38,8 +38,8 @@ class BinaryWeightRandomLoadBalancer(
         return BinaryChooser(serviceInstances)
     }
 
-    class BinaryChooser(instanceList: List<ServiceInstance>) : LoadBalancer.Chooser {
-        private val instanceList = instanceList.filterNot { it.weight == LoadBalancer.ZERO }
+    class BinaryChooser(instances: List<ServiceInstance>) : LoadBalancer.Chooser {
+        private val instanceList = instances.filterNot { it.weight == LoadBalancer.ZERO }
         private val totalWeight: Int
         private val randomBound: Int
         private val weightLine: IntArray = IntArray(instanceList.size)

--- a/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/loadbalancer/BinaryWeightRandomLoadBalancer.kt
+++ b/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/loadbalancer/BinaryWeightRandomLoadBalancer.kt
@@ -38,7 +38,8 @@ class BinaryWeightRandomLoadBalancer(
         return BinaryChooser(serviceInstances)
     }
 
-    class BinaryChooser(private val instanceList: List<ServiceInstance>) : LoadBalancer.Chooser {
+    class BinaryChooser(instanceList: List<ServiceInstance>) : LoadBalancer.Chooser {
+        private val instanceList = instanceList.filterNot { it.weight == LoadBalancer.ZERO }
         private val totalWeight: Int
         private val randomBound: Int
         private val weightLine: IntArray = IntArray(instanceList.size)

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/loadbalancer/ChooserSpec.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/loadbalancer/ChooserSpec.kt
@@ -16,6 +16,21 @@ abstract class ChooserSpec {
     abstract fun createChooser(instances: List<ServiceInstance>): LoadBalancer.Chooser
 
     @Test
+    fun ignoreZeroWeight() {
+        val serviceId = "zero-weight"
+        val active = TestServiceInstance.createInstance(serviceId)
+        val instances = listOf(
+            TestServiceInstance.createInstance(serviceId).withWeight(0),
+            active,
+            TestServiceInstance.createInstance(serviceId).withWeight(0),
+        )
+        val chooser = createChooser(instances)
+        repeat(10) {
+            chooser.choose().assert().isEqualTo(active)
+        }
+    }
+
+    @Test
     fun choose() {
         val serviceId = "ChooserSpec"
         val totalTimes = 1000_000_0


### PR DESCRIPTION
## What changed

- exclude zero-weight instances from `BinaryChooser`
- add a shared weighted-chooser contract test with zero-weight instances before and after the active instance

## Why

The binary chooser's first/last fast paths could select zero-weight instances. With weights `[0, 1]`, the disabled first instance received every request.

## Validation

- `./gradlew :cosky-discovery:test --tests '*ChooserTest.ignoreZeroWeight'`
- `./gradlew :cosky-discovery:test :cosky-discovery:detekt`
- `git diff --check`