### PR TITLE
Fix deregistration renewal state

### DIFF
--- a/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt
+++ b/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt
@@ -193,8 +193,10 @@ class RedisServiceRegistry(
             "Deregister - instanceId:[$instanceId] @ namespace:[$namespace]."
         }
         return deregisterInternal(namespace, serviceId, instanceId)
-            .doOnSubscribe {
-                removeEphemeralInstance(namespace, instanceId)
+            .doOnNext { deregistered ->
+                if (deregistered) {
+                    removeEphemeralInstance(namespace, instanceId)
+                }
             }
     }
 
@@ -203,8 +205,10 @@ class RedisServiceRegistry(
             "Deregister - instanceId:[${serviceInstance.instanceId}] @ namespace:[$namespace]."
         }
         return deregisterInternal(namespace, serviceInstance.serviceId, serviceInstance.instanceId)
-            .doOnSubscribe {
-                removeEphemeralInstance(namespace, serviceInstance)
+            .doOnNext { deregistered ->
+                if (deregistered) {
+                    removeEphemeralInstance(namespace, serviceInstance)
+                }
             }
     }
 

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceRegistryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceRegistryTest.kt
@@ -181,10 +181,13 @@ class RedisServiceRegistryTest : AbstractReactiveRedisTest() {
     @Test
     fun deregister() {
         val testInstance = randomInstance()
+        val namespacedInstanceId = NamespacedInstanceId(namespace, testInstance.instanceId)
+        serviceRegistry.registeredEphemeralInstances[namespacedInstanceId] = testInstance
         serviceRegistry.deregister(namespace, testInstance)
             .test()
             .expectNext(false)
             .verifyComplete()
+        serviceRegistry.registeredEphemeralInstances[namespacedInstanceId].assert().isEqualTo(testInstance)
         serviceRegistry.register(namespace, testInstance)
             .test()
             .expectNext(true)
@@ -193,6 +196,25 @@ class RedisServiceRegistryTest : AbstractReactiveRedisTest() {
             .test()
             .expectNext(true)
             .verifyComplete()
+        serviceRegistry.registeredEphemeralInstances.containsKey(namespacedInstanceId).assert().isFalse()
+    }
+
+    @Test
+    fun deregisterFailurePreservesEphemeralRenewal() {
+        val failedRedisTemplate = mockk<ReactiveStringRedisTemplate>()
+        every {
+            failedRedisTemplate.execute(any<RedisScript<Boolean>>(), any(), any())
+        } returns Flux.error(IllegalStateException("deregistration failed"))
+        val failedRegistry = RedisServiceRegistry(RegistryProperties(Duration.ofSeconds(10)), failedRedisTemplate)
+        val ephemeralInstance = randomInstance()
+        val namespacedInstanceId = NamespacedInstanceId(namespace, ephemeralInstance.instanceId)
+        failedRegistry.registeredEphemeralInstances[namespacedInstanceId] = ephemeralInstance
+
+        failedRegistry.deregister(namespace, ephemeralInstance.serviceId, ephemeralInstance.instanceId)
+            .test()
+            .expectErrorMessage("deregistration failed")
+            .verify()
+        failedRegistry.registeredEphemeralInstances[namespacedInstanceId].assert().isEqualTo(ephemeralInstance)
     }
 
     @Test


### PR DESCRIPTION
## What
- remove an ephemeral instance from the local renewal set only after Redis confirms deregistration
- preserve renewal state when deregistration returns `false` or fails
- cover false, success, and error outcomes

## Why
Removing the instance at subscription time stops renewal even when Redis never deregisters it, allowing a still-registered ephemeral instance to expire.

## Validation
- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.RedisServiceRegistryTest :cosky-discovery:detekt`
- `./gradlew :cosky-discovery:test`
- `git diff --check`