### PR TITLE
Fix cached instance fallback

### DIFF
--- a/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/ConsistencyRedisServiceDiscovery.kt
+++ b/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/ConsistencyRedisServiceDiscovery.kt
@@ -121,9 +121,9 @@ class ConsistencyRedisServiceDiscovery(
 
         return instancesMono
             .flatMapIterable(Function.identity())
-            .switchIfEmpty(delegate.getInstance(namespace, serviceId, instanceId))
             .filter { it.instanceId == instanceId }
             .next()
+            .switchIfEmpty(delegate.getInstance(namespace, serviceId, instanceId))
     }
 
     override fun getInstance(namespace: String, serviceId: String, instanceId: String): Mono<ServiceInstance> {

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/ConsistencyRedisServiceDiscoveryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/ConsistencyRedisServiceDiscoveryTest.kt
@@ -12,7 +12,10 @@
  */
 package me.ahoo.cosky.discovery
 
+import io.mockk.every
+import io.mockk.mockk
 import me.ahoo.cosid.test.MockIdGenerator
+import me.ahoo.cosky.discovery.ServiceInstance.Companion.withIsEphemeral
 import me.ahoo.cosky.discovery.TestServiceInstance.createInstance
 import me.ahoo.cosky.discovery.TestServiceInstance.registerRandomInstanceAndTestThenDeregister
 import me.ahoo.cosky.discovery.redis.ConsistencyRedisServiceDiscovery
@@ -24,6 +27,8 @@ import me.ahoo.cosky.test.AbstractReactiveRedisTest
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 import reactor.test.StepVerifier
 import java.time.Duration
@@ -127,6 +132,31 @@ class ConsistencyRedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
                 .expectNextMatches { it.t1 === it.t2 }
                 .verifyComplete()
         }
+    }
+
+    @Test
+    fun getInstanceFallsBackWhenCachedServiceMissesInstance() {
+        val namespace = MockIdGenerator.INSTANCE.generateAsString()
+        val serviceId = MockIdGenerator.INSTANCE.generateAsString()
+        val cachedInstance = createInstance(serviceId).withIsEphemeral(false)
+        val missingInstance = createInstance(serviceId).withIsEphemeral(false)
+        val delegate = mockk<ServiceDiscovery>()
+        every { delegate.getInstances(namespace, serviceId) } returns Flux.just(cachedInstance)
+        every { delegate.getInstance(namespace, serviceId, missingInstance.instanceId) } returns Mono.just(missingInstance)
+        val instanceEventListenerContainer = mockk<InstanceEventListenerContainer>()
+        every { instanceEventListenerContainer.receive(any()) } returns Flux.never()
+        val serviceDiscovery = ConsistencyRedisServiceDiscovery(
+            delegate = delegate,
+            serviceEventListenerContainer = mockk(),
+            instanceEventListenerContainer = instanceEventListenerContainer,
+        )
+
+        serviceDiscovery.getInstances(namespace, serviceId).test()
+            .expectNext(cachedInstance)
+            .verifyComplete()
+        serviceDiscovery.getInstance(namespace, serviceId, missingInstance.instanceId).test()
+            .expectNext(missingInstance)
+            .verifyComplete()
     }
 
     @Test


### PR DESCRIPTION
## What
- filter the cached service instances by `instanceId` before deciding whether the cache is empty
- fall back to the delegate when the service cache exists but does not contain the requested instance
- add a deterministic regression test with a populated cache and delegate-only instance

## Why
The previous operator order only fell back when the entire service cache was empty. A cache containing another instance caused `getInstance` to complete empty even when Redis had the requested instance.

## Validation
- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.ConsistencyRedisServiceDiscoveryTest :cosky-discovery:detekt`
- `./gradlew :cosky-discovery:test`
- `git diff --check`