### PR TITLE
Fix instance service membership

### DIFF
--- a/cosky-discovery/src/main/resources/discovery_get_instance.lua
+++ b/cosky-discovery/src/main/resources/discovery_get_instance.lua
@@ -6,6 +6,10 @@ local serviceId = ARGV[1];
 local instanceId = ARGV[2];
 local instanceIdxKey = namespace .. ':svc_itc_idx:' .. serviceId;
 
+if redis.call("sismember", instanceIdxKey, instanceId) == 0 then
+    return {  }
+end
+
 local function getInstanceKey(instanceId)
     return namespace .. ":svc_itc:" .. instanceId;
 end
@@ -37,5 +41,4 @@ if instanceTtl ~= -2 then
 end
 
 return {  }
-
 

--- a/cosky-discovery/src/main/resources/discovery_get_instance_ttl.lua
+++ b/cosky-discovery/src/main/resources/discovery_get_instance_ttl.lua
@@ -6,6 +6,10 @@ local serviceId = ARGV[1];
 local instanceId = ARGV[2];
 local instanceIdxKey = namespace .. ':svc_itc_idx:' .. serviceId;
 
+if redis.call("sismember", instanceIdxKey, instanceId) == 0 then
+    return -2;
+end
+
 local function getInstanceKey(instanceId)
     return namespace .. ":svc_itc:" .. instanceId;
 end
@@ -30,4 +34,3 @@ end
 local nowTime = redis.call('time')[1];
 local ttlAt = nowTime + instanceTtl;
 return ttlAt;
-

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceDiscoveryTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceDiscoveryTest.kt
@@ -85,6 +85,23 @@ class RedisServiceDiscoveryTest : AbstractReactiveRedisTest() {
     }
 
     @Test
+    fun getInstanceRejectsWrongService() {
+        registerRandomInstanceAndTestThenDeregister(
+            namespace,
+            redisServiceRegistry,
+        ) {
+            val wrongServiceId = MockIdGenerator.INSTANCE.generateAsString()
+            redisServiceDiscovery.getInstance(namespace, wrongServiceId, it.instanceId)
+                .test()
+                .verifyComplete()
+            redisServiceDiscovery.getInstanceTtl(namespace, wrongServiceId, it.instanceId)
+                .test()
+                .expectNext(-2)
+                .verifyComplete()
+        }
+    }
+
+    @Test
     fun getInstanceTtl() {
         registerRandomInstanceAndTestThenDeregister(
             namespace,


### PR DESCRIPTION
## What
- verify `instanceId` membership in the requested service index before reading the shared instance hash
- return the existing not-found results for cross-service instance and TTL lookups
- cover both lookup methods with a real Redis regression test

## Why
Instance hashes are keyed by namespace and instance ID. Without checking the service index, callers could retrieve an instance through an unrelated `serviceId`.

## Compatibility
- no Redis key or stored-data migration
- valid service lookups and expiry cleanup are unchanged
- cross-service lookups now correctly return not found

## Validation
- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.RedisServiceDiscoveryTest :cosky-discovery:detekt`
- `./gradlew :cosky-discovery:test`
- `git diff --check`