### PR TITLE
Fix multi-document property source

### DIFF
--- a/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyPropertySourceLocator.kt
+++ b/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyPropertySourceLocator.kt
@@ -21,6 +21,7 @@ import me.ahoo.cosky.core.NamespacedContext
 import org.springframework.boot.env.OriginTrackedMapPropertySource
 import org.springframework.boot.env.PropertySourceLoader
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator
+import org.springframework.core.env.CompositePropertySource
 import org.springframework.core.env.Environment
 import org.springframework.core.env.PropertySource
 import org.springframework.core.io.ByteArrayResource
@@ -88,24 +89,20 @@ class CoSkyPropertySourceLocator(
     private fun getCoSkyPropertySourceOfConfig(
         sourceLoader: PropertySourceLoader,
         config: Config
-    ): OriginTrackedMapPropertySource {
+    ): PropertySource<*> {
         val byteArrayResource = ByteArrayResource(config.data.toByteArray())
         val propertySourceList = sourceLoader.load(config.configId, byteArrayResource)
-        val source = getMapSource(config.configId, propertySourceList)
-        return OriginTrackedMapPropertySource(getNameOfConfigId(config.configId), source)
-    }
-
-    private fun getMapSource(configId: String, propertySourceList: List<PropertySource<*>>): Map<String, Any> {
-        if (propertySourceList.isEmpty()) {
-            return emptyMap()
+        val name = getNameOfConfigId(config.configId)
+        if (propertySourceList.size > 1) {
+            val composite = CompositePropertySource(name)
+            propertySourceList.forEach { composite.addFirstPropertySource(it) }
+            return composite
         }
-        if (propertySourceList.size == 1) {
-            val propertySource = propertySourceList[0]
-            if (propertySource.source is Map<*, *>) {
-                @Suppress("UNCHECKED_CAST")
-                return propertySource.source as Map<String, Any>
-            }
+        val source = propertySourceList.singleOrNull()?.source
+        if (source !is Map<*, *>) {
+            return OriginTrackedMapPropertySource(name, emptyMap<Any, Any>())
         }
-        return mapOf(getNameOfConfigId(configId) to propertySourceList)
+        @Suppress("UNCHECKED_CAST")
+        return OriginTrackedMapPropertySource(name, source as Map<String, Any>)
     }
 }

--- a/cosky-spring-cloud-starter-config/src/test/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyPropertySourceLocatorTest.kt
+++ b/cosky-spring-cloud-starter-config/src/test/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyPropertySourceLocatorTest.kt
@@ -67,4 +67,30 @@ internal class CoSkyPropertySourceLocatorTest : AbstractReactiveRedisTest() {
         source["spring.cloud.cosky.discovery.registry.weight"]?.value.assert().isEqualTo(8)
         source["cosid.namespace"]?.value.assert().isEqualTo("service")
     }
+
+    @Test
+    fun locateMultiDocumentYaml() {
+        val configId = "multi-document.yaml"
+        val configData = """
+            shared: first
+            first:
+              value: one
+            ---
+            shared: second
+            second:
+              value: two
+        """.trimIndent()
+        configService.setConfig(NamespacedContext.namespace, configId, configData)
+            .test()
+            .expectNextCount(1)
+            .verifyComplete()
+        val propertySource = CoSkyPropertySourceLocator(
+            CoSkyConfigProperties(configId = configId),
+            configService,
+        ).locate(mockk())
+
+        propertySource.getProperty("first.value").assert().isEqualTo("one")
+        propertySource.getProperty("second.value").assert().isEqualTo("two")
+        propertySource.getProperty("shared").assert().isEqualTo("second")
+    }
 }


### PR DESCRIPTION
## What
- represent multi-document YAML with Spring's native `CompositePropertySource`
- preserve document order so later YAML documents override earlier ones
- keep the existing single-document `OriginTrackedMapPropertySource` behavior
- add a Redis-backed locator regression test for both document visibility and override precedence

## Why
The previous multi-document fallback stored the loader's property-source list under one synthetic map key, so normal property lookup could not see any document fields.

## Compatibility
- single-document behavior is unchanged
- no new dependency
- per-document origin metadata is preserved

## Validation
- `./gradlew :cosky-spring-cloud-starter-config:test :cosky-spring-cloud-starter-config:detekt`
- `git diff --check`