### PR TITLE
Fix expired instance count

### DIFF
--- a/cosky-discovery/src/main/resources/instance_count_stat.lua
+++ b/cosky-discovery/src/main/resources/instance_count_stat.lua
@@ -7,10 +7,21 @@ local function getInstanceIdxKey(serviceId)
     return namespace .. ":svc_itc_idx:" .. serviceId;
 end
 
+local function getInstanceKey(instanceId)
+    return namespace .. ":svc_itc:" .. instanceId;
+end
+
 local function statInstance(serviceId)
     local instanceIdxKey = getInstanceIdxKey(serviceId);
-    local servicedInstanceCount = redis.call("scard", instanceIdxKey);
-    instanceCount = instanceCount + servicedInstanceCount;
+    local instanceIds = redis.call("smembers", instanceIdxKey);
+    for index, instanceId in ipairs(instanceIds) do
+        local instanceKey = getInstanceKey(instanceId);
+        if redis.call("exists", instanceKey) == 1 then
+            instanceCount = instanceCount + 1;
+        elseif redis.call("srem", instanceIdxKey, instanceId) > 0 then
+            redis.call("publish", instanceKey, "expired");
+        end
+    end
 end
 
 local serviceIds = redis.call("smembers", serviceIdxKey);

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceStatisticTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/RedisServiceStatisticTest.kt
@@ -13,6 +13,8 @@
 package me.ahoo.cosky.discovery
 
 import me.ahoo.cosid.test.MockIdGenerator
+import me.ahoo.cosky.discovery.DiscoveryKeyGenerator.getInstanceIdxKey
+import me.ahoo.cosky.discovery.DiscoveryKeyGenerator.getInstanceKey
 import me.ahoo.cosky.discovery.TestServiceInstance.randomInstance
 import me.ahoo.cosky.discovery.redis.RedisInstanceEventListenerContainer
 import me.ahoo.cosky.discovery.redis.RedisServiceRegistry
@@ -82,6 +84,33 @@ class RedisServiceStatisticTest : AbstractReactiveRedisTest() {
         redisServiceStatistic.getInstanceCount(namespace)
             .test()
             .expectNext(0)
+            .verifyComplete()
+    }
+
+    @Test
+    fun getInstanceCountIgnoresExpiredIndexMembers() {
+        val namespace = MockIdGenerator.INSTANCE.generateAsString()
+        val instance = randomInstance()
+        serviceRegistry.register(namespace, instance)
+            .test()
+            .expectNext(true)
+            .verifyComplete()
+        redisServiceStatistic.getInstanceCount(namespace)
+            .test()
+            .expectNext(1)
+            .verifyComplete()
+
+        redisTemplate.delete(getInstanceKey(namespace, instance.instanceId))
+            .test()
+            .expectNext(1)
+            .verifyComplete()
+        redisServiceStatistic.getInstanceCount(namespace)
+            .test()
+            .expectNext(0)
+            .verifyComplete()
+        redisTemplate.opsForSet().isMember(getInstanceIdxKey(namespace, instance.serviceId), instance.instanceId)
+            .test()
+            .expectNext(false)
             .verifyComplete()
     }
 


### PR DESCRIPTION
## What
- count only service-index members whose instance hash still exists
- lazily remove expired index members and publish the existing `expired` event
- add a real Redis regression covering live count, simulated expiry, zero count, and index cleanup

## Why
`SCARD` counted stale members until another discovery path happened to clean them, so the namespace instance total could remain inflated after TTL expiry.

## Compatibility
- no Redis key or stored-data migration
- cleanup follows the same event convention as discovery lookups
- accurate counting now scans indexed instances instead of only set cardinalities

## Validation
- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.RedisServiceStatisticTest :cosky-discovery:detekt`
- `./gradlew :cosky-discovery:test`
- `git diff --check`