### PR TITLE
Fix colon config ID parsing

### DIFF
--- a/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigKeyGenerator.kt
+++ b/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigKeyGenerator.kt
@@ -73,10 +73,12 @@ object ConfigKeyGenerator {
     fun getConfigVersionOfHistoryKey(namespace: String, configHistoryKey: String): ConfigVersion {
         val configHistoryKeyPrefix = "$namespace:$CONFIG_HISTORY:"
         val configIdWithVersion = configHistoryKey.substring(configHistoryKeyPrefix.length)
-        val configIdWithVersionSplit: Array<String> =
-            configIdWithVersion.split(CoSky.KEY_SEPARATOR.toRegex()).dropWhile { it.isEmpty() }
-                .toTypedArray()
-        require(configIdWithVersionSplit.size == 2) { "configHistoryKey:[$configHistoryKey] format error." }
-        return ConfigVersionData(configIdWithVersionSplit[0], configIdWithVersionSplit[1].toInt())
+        val versionSeparatorIndex = configIdWithVersion.lastIndexOf(CoSky.KEY_SEPARATOR)
+        require(versionSeparatorIndex in 1 until configIdWithVersion.lastIndex) {
+            "configHistoryKey:[$configHistoryKey] format error."
+        }
+        val configId = configIdWithVersion.substring(0, versionSeparatorIndex)
+        val version = configIdWithVersion.substring(versionSeparatorIndex + CoSky.KEY_SEPARATOR.length).toInt()
+        return ConfigVersionData(configId, version)
     }
 }

--- a/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/RedisConfigServiceTest.kt
+++ b/cosky-config/src/test/kotlin/me/ahoo/cosky/config/redis/RedisConfigServiceTest.kt
@@ -48,4 +48,23 @@ class RedisConfigServiceTest : ConfigServiceSpec() {
             }
             .verifyComplete()
     }
+
+    @Test
+    fun getConfigVersionsWithColonInConfigId() {
+        val namespace = MockIdGenerator.INSTANCE.generateAsString()
+        val configId = "${MockIdGenerator.INSTANCE.generateAsString()}:profile"
+        configService.setConfig(namespace, configId, "version-1")
+            .then(configService.setConfig(namespace, configId, "version-2"))
+            .test()
+            .expectNext(true)
+            .verifyComplete()
+        configService.getConfigVersions(namespace, configId)
+            .test()
+            .expectNextMatches {
+                it.configId.assert().isEqualTo(configId)
+                it.version.assert().isEqualTo(1)
+                true
+            }
+            .verifyComplete()
+    }
 }


### PR DESCRIPTION
## What
- parse a config history key at its final separator instead of splitting every colon
- retain all earlier separators as part of `configId`
- add a real Redis version-history regression for a colon-containing config ID

## Why
History keys end with `:<version>`, but config IDs may also contain colons. Splitting the full suffix required exactly two segments and rejected otherwise valid IDs.

## Compatibility
- Redis key generation is unchanged
- existing config IDs parse identically
- malformed keys still fail validation

## Validation
- `./gradlew :cosky-config:test --tests me.ahoo.cosky.config.redis.RedisConfigServiceTest :cosky-config:detekt`
- `./gradlew :cosky-config:test`
- `git diff --check`