### PR TITLE
Reject reserved metadata keys

### DIFF
--- a/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt
+++ b/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt
@@ -34,6 +34,9 @@ object ServiceInstanceCodec {
     private const val TTL_AT = "ttl_at"
 
     fun encodeMetadataKey(key: String): String {
+        require(!key.startsWith(METADATA_PREFIX)) {
+            "metadata key:[$key] must not start with reserved prefix [$METADATA_PREFIX]."
+        }
         return METADATA_PREFIX + key
     }
 

--- a/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodecTest.kt
+++ b/cosky-discovery/src/test/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodecTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosky.discovery
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import org.junit.jupiter.api.Test
+
+class ServiceInstanceCodecTest {
+    @Test
+    fun encodeMetadataKey() {
+        ServiceInstanceCodec.encodeMetadataKey("version").assert().isEqualTo("_version")
+        assertThrownBy<IllegalArgumentException> {
+            ServiceInstanceCodec.encodeMetadataKey("_reserved")
+        }.hasMessage("metadata key:[_reserved] must not start with reserved prefix [_].")
+    }
+}

--- a/wiki/guide/service-registry.md
+++ b/wiki/guide/service-registry.md
@@ -42,7 +42,7 @@ A [`ServiceInstance`](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discove
 | `weight` | `Int` | `1` | Load balancer weight |
 | `isEphemeral` | `Boolean` | `true` | Ephemeral instances expire; persistent instances do not |
 | `ttlAt` | `Long` | `TTL_AT_FOREVER (-1)` | Absolute TTL expiry timestamp (epoch seconds) |
-| `metadata` | `Map<String, String>` | `emptyMap()` | Arbitrary key-value metadata attached to the instance |
+| `metadata` | `Map<String, String>` | `emptyMap()` | User-defined key-value metadata; keys beginning with `_` are rejected |
 
 The `isExpired` property on `ServiceInstance` compares `ttlAt` against the current system time to determine whether an ephemeral instance has expired ([ServiceInstance.kt:34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstance.kt#L34)).
 
@@ -54,6 +54,8 @@ The `isExpired` property on `ServiceInstance` compares `ttlAt` against the curre
 // Encoding: metadata key "version" becomes "_version" in Redis
 fun encodeMetadataKey(key: String): String = METADATA_PREFIX + key
 ```
+
+Metadata keys must not begin with `_`. That prefix is reserved for internal fields such as `__last_renew_pub_ttl_at`; rejecting it prevents user metadata from colliding with registry state.
 
 The `decode` function ([ServiceInstanceCodec.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt#L57)) parses the flat key-value list returned by Redis `HGETALL` into a `ServiceInstance` object.
 

--- a/wiki/guide/service-registry.md
+++ b/wiki/guide/service-registry.md
@@ -52,7 +52,10 @@ The `isExpired` property on `ServiceInstance` compares `ttlAt` against the curre
 
 ```kotlin
 // Encoding: metadata key "version" becomes "_version" in Redis
-fun encodeMetadataKey(key: String): String = METADATA_PREFIX + key
+fun encodeMetadataKey(key: String): String {
+    require(!key.startsWith(METADATA_PREFIX))
+    return METADATA_PREFIX + key
+}
 ```
 
 Metadata keys must not begin with `_`. That prefix is reserved for internal fields such as `__last_renew_pub_ttl_at`; rejecting it prevents user metadata from colliding with registry state.

--- a/wiki/zh/guide/service-registry.md
+++ b/wiki/zh/guide/service-registry.md
@@ -52,7 +52,10 @@ CoSky 的服务注册管理微服务集群中服务实例的生命周期。基�
 
 ```kotlin
 // 编码：元数据键 "version" 在 Redis 中变为 "_version"
-fun encodeMetadataKey(key: String): String = METADATA_PREFIX + key
+fun encodeMetadataKey(key: String): String {
+    require(!key.startsWith(METADATA_PREFIX))
+    return METADATA_PREFIX + key
+}
 ```
 
 元数据键不得以 `_` 开头。该前缀保留给 `__last_renew_pub_ttl_at` 等内部字段；拒绝此类键可防止用户元数据与注册中心状态冲突。

--- a/wiki/zh/guide/service-registry.md
+++ b/wiki/zh/guide/service-registry.md
@@ -42,7 +42,7 @@ CoSky 的服务注册管理微服务集群中服务实例的生命周期。基�
 | `weight` | `Int` | `1` | 负载均衡权重 |
 | `isEphemeral` | `Boolean` | `true` | 临时实例会过期；持久实例不会 |
 | `ttlAt` | `Long` | `TTL_AT_FOREVER (-1)` | 绝对 TTL 过期时间戳（纪元秒） |
-| `metadata` | `Map<String, String>` | `emptyMap()` | 附加到实例的任意键值元数据 |
+| `metadata` | `Map<String, String>` | `emptyMap()` | 用户自定义键值元数据；拒绝以 `_` 开头的键 |
 
 `ServiceInstance` 上的 `isExpired` 属性将 `ttlAt` 与当前系统时间比较，以确定临时实例是否已过期 ([ServiceInstance.kt:34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstance.kt#L34))。
 
@@ -54,6 +54,8 @@ CoSky 的服务注册管理微服务集群中服务实例的生命周期。基�
 // 编码：元数据键 "version" 在 Redis 中变为 "_version"
 fun encodeMetadataKey(key: String): String = METADATA_PREFIX + key
 ```
+
+元数据键不得以 `_` 开头。该前缀保留给 `__last_renew_pub_ttl_at` 等内部字段；拒绝此类键可防止用户元数据与注册中心状态冲突。
 
 `decode` 函数 ([ServiceInstanceCodec.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt#L57)) 将 Redis `HGETALL` 返回的扁平键值列表解析为 `ServiceInstance` 对象。
 


### PR DESCRIPTION
## What
- reject user metadata keys that begin with `_` at the shared encoding boundary
- preserve the existing encoding of valid metadata keys
- document the reserved prefix in both service-registry guides
- add a focused codec regression test

## Why
CoSky prefixes user metadata with `_` and reserves `__` for internal fields such as `__last_renew_pub_ttl_at`. A user key such as `_foo` was therefore encoded into the system namespace, silently omitted during decoding, and could collide with registry state.

## Compatibility
- no Redis key, hash-field, or stored-data migration
- valid metadata is unchanged
- previously accepted leading-underscore keys now fail fast; REST maps the exception to HTTP 400

## Validation
- `./gradlew :cosky-discovery:test --tests me.ahoo.cosky.discovery.ServiceInstanceCodecTest :cosky-discovery:detekt`
- `./gradlew :cosky-discovery:test`
- `git diff --check`