### PR TITLE
Normalize REST namespaces before authorization

### DIFF
--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/config/ConfigController.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/config/ConfigController.kt
@@ -20,6 +20,7 @@ import me.ahoo.cosky.config.ConfigService
 import me.ahoo.cosky.config.ConfigVersion
 import me.ahoo.cosky.core.CoSky
 import me.ahoo.cosky.rest.support.RequestPathPrefix
+import me.ahoo.cosky.rest.support.normalizeNamespace
 import me.ahoo.cosky.rest.util.Zips.ZipItem.Companion.of
 import me.ahoo.cosky.rest.util.Zips.unzip
 import me.ahoo.cosky.rest.util.Zips.zip
@@ -63,7 +64,7 @@ class ConfigController(private val configService: ConfigService) {
 
     @GetMapping
     fun getConfigs(@PathVariable namespace: String): Mono<List<String>> {
-        return configService.getConfigs(namespace).collectList()
+        return configService.getConfigs(namespace.normalizeNamespace()).collectList()
     }
 
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -72,6 +73,7 @@ class ConfigController(private val configService: ConfigService) {
         @RequestParam(required = false) policy: String?,
         @RequestPart importZip: Mono<FilePart>
     ): Mono<ImportResponse> {
+        val normalizedNamespace = namespace.normalizeNamespace()
         val importPolicy = if (policy.isNullOrEmpty()) {
             IMPORT_POLICY_SKIP
         } else {
@@ -106,22 +108,26 @@ class ConfigController(private val configService: ConfigService) {
                 val configData = zipItem.data
                 when (importPolicy) {
                     IMPORT_POLICY_OVERWRITE -> {
-                        return@flatMap configService.setConfig(namespace, configId, configData)
+                        return@flatMap configService.setConfig(normalizedNamespace, configId, configData)
                     }
 
                     IMPORT_POLICY_SKIP -> {
-                        return@flatMap configService.containsConfig(namespace, configId)
+                        return@flatMap configService.containsConfig(normalizedNamespace, configId)
                             .filter { contained ->
                                 if (contained) {
                                     if (log.isInfoEnabled) {
-                                        log.info("ImportZip - Skip - [{}]@[{}] has contained.", configId, namespace)
+                                        log.info(
+                                            "ImportZip - Skip - [{}]@[{}] has contained.",
+                                            configId,
+                                            normalizedNamespace,
+                                        )
                                     }
                                 }
                                 !contained
                             }
                             .flatMap {
                                 configService.setConfig(
-                                    namespace,
+                                    normalizedNamespace,
                                     configId,
                                     configData,
                                 )
@@ -149,15 +155,16 @@ class ConfigController(private val configService: ConfigService) {
 
     @GetMapping(RequestPathPrefix.CONFIGS_CONFIG_EXPORT)
     fun exportZip(@PathVariable namespace: String): Mono<ResponseEntity<ByteArray>> {
-        return configService.getConfigs(namespace)
+        val normalizedNamespace = namespace.normalizeNamespace()
+        return configService.getConfigs(normalizedNamespace)
             .flatMap {
-                configService.getConfig(namespace, it)
+                configService.getConfig(normalizedNamespace, it)
             }
             .map { of(it.configId, it.data) }
             .collectList()
             .map {
                 val headers = HttpHeaders()
-                val fileName = "${CoSky.COSKY}_${namespace}_config_${System.currentTimeMillis()}.zip"
+                val fileName = "${CoSky.COSKY}_${normalizedNamespace}_config_${System.currentTimeMillis()}.zip"
                 headers.add("Content-Disposition", "attachment;filename=$fileName")
                 headers.contentType = MediaType.APPLICATION_OCTET_STREAM
                 ResponseEntity(zip(it), headers, HttpStatus.OK)
@@ -170,17 +177,17 @@ class ConfigController(private val configService: ConfigService) {
         @PathVariable configId: String,
         @RequestBody data: String
     ): Mono<Boolean> {
-        return configService.setConfig(namespace, configId, data)
+        return configService.setConfig(namespace.normalizeNamespace(), configId, data)
     }
 
     @DeleteMapping(RequestPathPrefix.CONFIGS_CONFIG)
     fun removeConfig(@PathVariable namespace: String, @PathVariable configId: String): Mono<Boolean> {
-        return configService.removeConfig(namespace, configId)
+        return configService.removeConfig(namespace.normalizeNamespace(), configId)
     }
 
     @GetMapping(RequestPathPrefix.CONFIGS_CONFIG)
     fun getConfig(@PathVariable namespace: String, @PathVariable configId: String): Mono<Config> {
-        return configService.getConfig(namespace, configId)
+        return configService.getConfig(namespace.normalizeNamespace(), configId)
     }
 
     @PutMapping(RequestPathPrefix.CONFIGS_CONFIG_TO)
@@ -189,7 +196,7 @@ class ConfigController(private val configService: ConfigService) {
         @PathVariable configId: String,
         @PathVariable targetVersion: Int
     ): Mono<Boolean> {
-        return configService.rollback(namespace, configId, targetVersion)
+        return configService.rollback(namespace.normalizeNamespace(), configId, targetVersion)
     }
 
     @GetMapping(RequestPathPrefix.CONFIGS_CONFIG_VERSIONS)
@@ -197,7 +204,7 @@ class ConfigController(private val configService: ConfigService) {
         @PathVariable namespace: String,
         @PathVariable configId: String
     ): Mono<List<ConfigVersion>> {
-        return configService.getConfigVersions(namespace, configId).collectList()
+        return configService.getConfigVersions(namespace.normalizeNamespace(), configId).collectList()
     }
 
     @GetMapping(RequestPathPrefix.CONFIGS_CONFIG_VERSIONS_VERSION)
@@ -206,6 +213,6 @@ class ConfigController(private val configService: ConfigService) {
         @PathVariable configId: String,
         @PathVariable version: Int
     ): Mono<ConfigHistory> {
-        return configService.getConfigHistory(namespace, configId, version)
+        return configService.getConfigHistory(namespace.normalizeNamespace(), configId, version)
     }
 }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt
@@ -20,6 +20,7 @@ import me.ahoo.cosky.core.NamespacedContext.namespace
 import me.ahoo.cosky.rest.security.rbac.RbacService
 import me.ahoo.cosky.rest.security.user.AdminPrincipal.isAdmin
 import me.ahoo.cosky.rest.support.RequestPathPrefix
+import me.ahoo.cosky.rest.support.normalizeNamespace
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -55,16 +56,16 @@ class NamespaceController(private val namespaceService: NamespaceService, privat
 
     @PutMapping(RequestPathPrefix.NAMESPACES_CURRENT_NAMESPACE)
     fun setCurrentContextNamespace(@PathVariable namespace: String) {
-        NamespacedContext.namespace = namespace
+        NamespacedContext.namespace = namespace.normalizeNamespace()
     }
 
     @PutMapping(RequestPathPrefix.NAMESPACES_NAMESPACE)
     fun setNamespace(@PathVariable namespace: String): Mono<Boolean> {
-        return namespaceService.setNamespace(namespace)
+        return namespaceService.setNamespace(namespace.normalizeNamespace())
     }
 
     @DeleteMapping(RequestPathPrefix.NAMESPACES_NAMESPACE)
     fun removeNamespace(@PathVariable namespace: String): Mono<Boolean> {
-        return namespaceService.removeNamespace(namespace)
+        return namespaceService.removeNamespace(namespace.normalizeNamespace())
     }
 }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authorization/NamespaceRequestAttributesAppender.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authorization/NamespaceRequestAttributesAppender.kt
@@ -1,15 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package me.ahoo.cosky.rest.security.authorization
 
 import me.ahoo.cosec.api.context.request.Request
 import me.ahoo.cosec.context.request.RequestAttributesAppender
 import me.ahoo.cosec.webflux.ReactiveRequest
 import me.ahoo.cosky.rest.support.RequestPathPrefix
+import me.ahoo.cosky.rest.support.normalizeNamespace
 import org.springframework.stereotype.Service
 import org.springframework.web.util.pattern.PathPatternParser
 
 @Service
 object NamespaceRequestAttributesAppender : RequestAttributesAppender {
     private const val NAMESPACE_KEY = "namespace"
+    private val currentNamespacePathPattern = PathPatternParser.defaultInstance.parse(
+        RequestPathPrefix.NAMESPACES_PREFIX + RequestPathPrefix.NAMESPACES_CURRENT_NAMESPACE,
+    )
     private val namespacePathPattern =
         PathPatternParser.defaultInstance.parse("${RequestPathPrefix.NAMESPACES_NAMESPACE_PREFIX}/**")
 
@@ -19,12 +35,20 @@ object NamespaceRequestAttributesAppender : RequestAttributesAppender {
 
     override fun append(request: Request): Request {
         val reactiveRequest = request as ReactiveRequest
-        namespacePathPattern.matchAndExtract(reactiveRequest.delegate.request.path)
-            ?.let { pathMatchInfo ->
-                pathMatchInfo.uriVariables[NAMESPACE_KEY]?.let {
-                    return request.mergeAttributes(mapOf(NAMESPACE_KEY to it))
-                }
-            }
-        return request
+        val requestPath = reactiveRequest.delegate.request.path
+        val namespace = currentNamespacePathPattern.matchAndExtract(requestPath)
+            ?.uriVariables
+            ?.get(NAMESPACE_KEY)
+            ?: namespacePathPattern.matchAndExtract(requestPath)
+                ?.uriVariables
+                ?.get(NAMESPACE_KEY)
+            ?: return request
+        val normalizedNamespace = try {
+            namespace.normalizeNamespace()
+        } catch (_: IllegalArgumentException) {
+            // Controller validation returns the client error without failing the authorization request parser.
+            namespace
+        }
+        return request.mergeAttributes(mapOf(NAMESPACE_KEY to normalizedNamespace))
     }
 }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/rbac/RbacService.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/rbac/RbacService.kt
@@ -15,6 +15,7 @@ package me.ahoo.cosky.rest.security.rbac
 import com.google.common.base.Strings
 import me.ahoo.cosky.core.Namespaced
 import me.ahoo.cosky.rest.security.rbac.Action.Companion.asAction
+import me.ahoo.cosky.rest.support.normalizeNamespace
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
@@ -89,7 +90,7 @@ class RbacService(private val redisTemplate: ReactiveStringRedisTemplate) {
             .switchIfEmpty(Mono.error(NotFoundRoleException(roleName)))
             .map { (key, value) ->
                 ResourceAction(
-                    key,
+                    key.normalizeNamespace(),
                     value.asAction(),
                 )
             }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/service/ServiceController.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/service/ServiceController.kt
@@ -20,6 +20,7 @@ import me.ahoo.cosky.discovery.ServiceStat
 import me.ahoo.cosky.discovery.ServiceStatistic
 import me.ahoo.cosky.discovery.loadbalancer.LoadBalancer
 import me.ahoo.cosky.rest.support.RequestPathPrefix
+import me.ahoo.cosky.rest.support.normalizeNamespace
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -45,22 +46,22 @@ class ServiceController(
 ) {
     @GetMapping
     fun getServices(@PathVariable namespace: String): Mono<List<String>> {
-        return discoveryService.getServices(namespace).collectList()
+        return discoveryService.getServices(namespace.normalizeNamespace()).collectList()
     }
 
     @PutMapping(RequestPathPrefix.SERVICES_SERVICE)
     fun setService(@PathVariable namespace: String, @PathVariable serviceId: String): Mono<Boolean> {
-        return serviceRegistry.setService(namespace, serviceId)
+        return serviceRegistry.setService(namespace.normalizeNamespace(), serviceId)
     }
 
     @DeleteMapping(RequestPathPrefix.SERVICES_SERVICE)
     fun removeService(@PathVariable namespace: String, @PathVariable serviceId: String): Mono<Boolean> {
-        return serviceRegistry.removeService(namespace, serviceId)
+        return serviceRegistry.removeService(namespace.normalizeNamespace(), serviceId)
     }
 
     @GetMapping(RequestPathPrefix.SERVICES_INSTANCES)
     fun getInstances(@PathVariable namespace: String, @PathVariable serviceId: String): Mono<List<ServiceInstance>> {
-        return discoveryService.getInstances(namespace, serviceId).collectList()
+        return discoveryService.getInstances(namespace.normalizeNamespace(), serviceId).collectList()
     }
 
     @PutMapping(RequestPathPrefix.SERVICES_INSTANCES)
@@ -69,7 +70,7 @@ class ServiceController(
         @PathVariable serviceId: String,
         @RequestBody instanceDto: InstanceDto
     ): Mono<Boolean> {
-        return serviceRegistry.register(namespace, instanceDto.asServiceInstance(serviceId))
+        return serviceRegistry.register(namespace.normalizeNamespace(), instanceDto.asServiceInstance(serviceId))
     }
 
     @DeleteMapping(RequestPathPrefix.SERVICES_INSTANCES_INSTANCE)
@@ -78,7 +79,7 @@ class ServiceController(
         @PathVariable serviceId: String,
         @PathVariable instanceId: String
     ): Mono<Boolean> {
-        return serviceRegistry.deregister(namespace, serviceId, instanceId)
+        return serviceRegistry.deregister(namespace.normalizeNamespace(), serviceId, instanceId)
     }
 
     @PutMapping(RequestPathPrefix.SERVICES_INSTANCES_INSTANCE_METADATA)
@@ -88,16 +89,16 @@ class ServiceController(
         @PathVariable instanceId: String,
         @RequestBody metadata: Map<String, String>
     ): Mono<Boolean> {
-        return serviceRegistry.setMetadata(namespace, serviceId, instanceId, metadata)
+        return serviceRegistry.setMetadata(namespace.normalizeNamespace(), serviceId, instanceId, metadata)
     }
 
     @GetMapping(RequestPathPrefix.SERVICES_STATS)
     fun getServiceStats(@PathVariable namespace: String): Mono<List<ServiceStat>> {
-        return serviceStatistic.getServiceStats(namespace).collectList()
+        return serviceStatistic.getServiceStats(namespace.normalizeNamespace()).collectList()
     }
 
     @GetMapping(RequestPathPrefix.SERVICES_LB)
     fun choose(@PathVariable namespace: String, @PathVariable serviceId: String): Mono<ServiceInstance> {
-        return loadBalancer.choose(namespace, serviceId)
+        return loadBalancer.choose(namespace.normalizeNamespace(), serviceId)
     }
 }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/stat/StatController.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/stat/StatController.kt
@@ -19,6 +19,7 @@ import me.ahoo.cosky.discovery.ServiceStat
 import me.ahoo.cosky.discovery.ServiceStatistic
 import me.ahoo.cosky.discovery.ServiceTopology
 import me.ahoo.cosky.rest.support.RequestPathPrefix
+import me.ahoo.cosky.rest.support.normalizeNamespace
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -42,14 +43,15 @@ class StatController(
 ) {
     @GetMapping
     fun getStat(@PathVariable namespace: String): Mono<GetStatResponse> {
+        val normalizedNamespace = namespace.normalizeNamespace()
         val getNamespacesFuture = namespaceService
             .namespaces
             .collect(Collectors.toSet())
         val getConfigsFuture = configService.getConfigs(
-            namespace,
+            normalizedNamespace,
         ).collect(Collectors.toSet())
         val getServiceStatsFuture = serviceStatistic
-            .getServiceStats(namespace)
+            .getServiceStats(normalizedNamespace)
             .collectList()
         return Mono.zip(getNamespacesFuture, getConfigsFuture, getServiceStatsFuture)
             .map {
@@ -72,6 +74,6 @@ class StatController(
 
     @GetMapping("topology")
     fun getTopology(@PathVariable namespace: String): Mono<Map<String, Set<String>>> {
-        return serviceTopology.getTopology(namespace)
+        return serviceTopology.getTopology(namespace.normalizeNamespace())
     }
 }

--- a/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/support/NamespaceNormalizer.kt
+++ b/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/support/NamespaceNormalizer.kt
@@ -10,20 +10,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cosky.rest.security.rbac
+package me.ahoo.cosky.rest.support
 
-import me.ahoo.cosky.rest.support.normalizeNamespace
+import me.ahoo.cosky.core.util.RedisKeys.hashTag
+import me.ahoo.cosky.core.util.RedisKeys.unwrap
 
-/**
- * Resource Action Dto.
- *
- * @author ahoo wang
- */
-data class ResourceActionDto(
-    var namespace: String,
-    var action: String
-) {
-    init {
-        namespace = namespace.normalizeNamespace()
-    }
+internal fun String.normalizeNamespace(): String {
+    require(isNotBlank()) { "namespace must not be blank!" }
+    val normalized = hashTag(this)
+    require(unwrap(normalized).isNotBlank()) { "namespace must contain a non-empty Redis hash tag!" }
+    return normalized
 }

--- a/cosky-rest-api/src/test/kotlin/me/ahoo/cosky/rest/security/authorization/NamespaceRequestAttributesAppenderTest.kt
+++ b/cosky-rest-api/src/test/kotlin/me/ahoo/cosky/rest/security/authorization/NamespaceRequestAttributesAppenderTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosky.rest.security.authorization
+
+import me.ahoo.cosec.webflux.ReactiveRequest
+import me.ahoo.cosky.rest.security.authorization.NamespaceRequestAttributesAppender.getNamespace
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import java.net.URI
+
+class NamespaceRequestAttributesAppenderTest {
+    @Test
+    fun `normalizes namespace before authorization`() {
+        val request = reactiveRequest(HttpMethod.GET, "/v1/namespaces/dev/configs")
+
+        NamespaceRequestAttributesAppender.append(request).getNamespace().assert().isEqualTo("{dev}")
+
+        val systemRequest = reactiveRequest(HttpMethod.GET, "/v1/namespaces/cosky-%7Bsystem%7D/configs")
+        NamespaceRequestAttributesAppender.append(systemRequest).getNamespace().assert().isEqualTo("cosky-{system}")
+    }
+
+    @Test
+    fun `normalizes current namespace selection`() {
+        val request = reactiveRequest(HttpMethod.PUT, "/v1/namespaces/current/dev")
+
+        NamespaceRequestAttributesAppender.append(request).getNamespace().assert().isEqualTo("{dev}")
+    }
+
+    private fun reactiveRequest(method: HttpMethod, path: String): ReactiveRequest {
+        val origin = URI.create("http://localhost")
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.method(method, origin.resolve(path)).build(),
+        )
+        return ReactiveRequest(
+            delegate = exchange,
+            path = path,
+            method = method.name(),
+            remoteIp = "127.0.0.1",
+            origin = origin,
+            referer = origin,
+            requestId = "request-id",
+        )
+    }
+}

--- a/cosky-rest-api/src/test/kotlin/me/ahoo/cosky/rest/security/rbac/ResourceActionDtoTest.kt
+++ b/cosky-rest-api/src/test/kotlin/me/ahoo/cosky/rest/security/rbac/ResourceActionDtoTest.kt
@@ -12,18 +12,13 @@
  */
 package me.ahoo.cosky.rest.security.rbac
 
-import me.ahoo.cosky.rest.support.normalizeNamespace
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
 
-/**
- * Resource Action Dto.
- *
- * @author ahoo wang
- */
-data class ResourceActionDto(
-    var namespace: String,
-    var action: String
-) {
-    init {
-        namespace = namespace.normalizeNamespace()
+class ResourceActionDtoTest {
+    @Test
+    fun `normalizes namespace`() {
+        ResourceActionDto("dev", "read").namespace.assert().isEqualTo("{dev}")
+        ResourceActionDto("cosky-{system}", "read").namespace.assert().isEqualTo("cosky-{system}")
     }
 }

--- a/cosky-rest-api/src/test/kotlin/me/ahoo/cosky/rest/support/NamespaceNormalizerTest.kt
+++ b/cosky-rest-api/src/test/kotlin/me/ahoo/cosky/rest/support/NamespaceNormalizerTest.kt
@@ -10,20 +10,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cosky.rest.security.rbac
+package me.ahoo.cosky.rest.support
 
-import me.ahoo.cosky.rest.support.normalizeNamespace
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import org.junit.jupiter.api.Test
 
-/**
- * Resource Action Dto.
- *
- * @author ahoo wang
- */
-data class ResourceActionDto(
-    var namespace: String,
-    var action: String
-) {
-    init {
-        namespace = namespace.normalizeNamespace()
+class NamespaceNormalizerTest {
+    @Test
+    fun normalizeNamespace() {
+        "dev".normalizeNamespace().assert().isEqualTo("{dev}")
+        "{dev}".normalizeNamespace().assert().isEqualTo("{dev}")
+        "cosky-{system}".normalizeNamespace().assert().isEqualTo("cosky-{system}")
+        assertThrownBy<IllegalArgumentException> {
+            "{}".normalizeNamespace()
+        }.hasMessage("namespace must contain a non-empty Redis hash tag!")
     }
 }

--- a/wiki/guide/rest-api.md
+++ b/wiki/guide/rest-api.md
@@ -74,6 +74,8 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 | PUT | `/v1/namespaces/{namespace}` | Create a namespace | `setNamespace` | [NamespaceController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L62) |
 | DELETE | `/v1/namespaces/{namespace}` | Remove a namespace | `removeNamespace` | [NamespaceController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L67) |
 
+Every `{namespace}` path value and role binding is normalized to a Redis hash-tagged form before authorization and service dispatch. For example, `dev` becomes `{dev}`; `{dev}` and `cosky-{system}` remain unchanged. Namespace lists and the current namespace return the normalized value. Empty hash tags such as `{}` are rejected.
+
 ### Stat Endpoints
 
 | Method | Path | Description | Controller Method | Source |

--- a/wiki/zh/guide/rest-api.md
+++ b/wiki/zh/guide/rest-api.md
@@ -74,6 +74,8 @@ fun main(args: Array<String>) {
 | PUT | `/v1/namespaces/{namespace}` | 创建命名空间 | `setNamespace` | [NamespaceController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L62) |
 | DELETE | `/v1/namespaces/{namespace}` | 移除命名空间 | `removeNamespace` | [NamespaceController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L67) |
 
+所有 `{namespace}` 路径值和角色绑定都会在鉴权和服务调用之前归一化为包含 Redis hashtag 的形式。例如，`dev` 会转换为 `{dev}`；`{dev}` 和 `cosky-{system}` 保持不变。命名空间列表和当前命名空间返回归一化后的值。`{}` 等空 hashtag 将被拒绝。
+
 ### 统计端点
 
 | 方法 | 路径 | 描述 | 控制器方法 | 源码 |


### PR DESCRIPTION
## Summary
- normalize every REST `{namespace}` path value with the existing Redis hash-tag utility before service dispatch
- normalize request attributes before RBAC checks and normalize role bindings on write/read
- reject empty Redis hash tags and document the canonical API behavior

## Compatibility and safety
- existing `{dev}`, `{prod}`, and `cosky-{system}` values remain unchanged
- plain REST values such as `dev` now intentionally resolve to `{dev}`
- no Lua script, Redis key generator, or stored Redis data is modified

## Verification
- `./gradlew :cosky-rest-api:test`
- `./gradlew :cosky-rest-api:detekt`
- `git diff --check`