### PR TITLE
Document namespace hash tag requirements

### DIFF
--- a/wiki/guide/core.md
+++ b/wiki/guide/core.md
@@ -137,9 +137,9 @@ object RedisKeys {
 }
 ```
 
-`RedisKeys` is an explicit utility, not a global key interceptor. `NamespaceService`, `ConfigKeyGenerator`, `DiscoveryKeyGenerator`, and the REST API preserve the namespace string supplied by the caller. `CoSkyProperties` applies `RedisKeys.ofKey(true, namespace)` to the Spring Cloud client's configured namespace, so its resulting value must exactly match the namespace used by the REST API and RBAC bindings.
+`RedisKeys` is an explicit utility, not a global key interceptor. `NamespaceService`, `ConfigKeyGenerator`, `DiscoveryKeyGenerator`, and the REST API preserve the namespace string supplied by the caller. Regardless of Redis topology, `CoSkyProperties` applies `RedisKeys.ofKey(true, namespace)` to the Spring Cloud client's configured namespace, so its effective value must exactly match the namespace used by the REST API and RBAC bindings.
 
-For Redis Cluster, choose a namespace containing a non-empty hash tag before writing data—for example, `{dev}`, `{prod}`, or `cosky-{system}`. Plain `dev` and tagged `{dev}` generate different physical keys. Converting an existing namespace requires an explicit data migration and rollback plan; changing only configuration makes the old data appear missing.
+For every deployment, choose a namespace containing a non-empty hash tag before writing data—for example, `{dev}`, `{prod}`, or `cosky-{dev}`. This is required for multi-key Lua operations in Redis Cluster and prevents standalone REST clients from diverging from Spring's effective namespace. Plain `dev` and tagged `{dev}` generate different physical keys. Converting an existing namespace requires an explicit data migration and rollback plan; changing only configuration makes the old data appear missing.
 
 ### Key Pattern Reference
 
@@ -343,20 +343,19 @@ sequenceDiagram
 
 ## Namespace-Scoped Operations Flow
 
-Every operation in CoSky flows through the namespace model. The following diagram illustrates how a typical service discovery request resolves keys within a namespace scope:
+Every operation in CoSky flows through the namespace model. `CoSkyProperties` wraps the Spring Cloud client's configured namespace before storing it as the default context; explicitly supplied namespaces pass through unchanged. The following diagram illustrates how a typical service discovery request resolves keys within a namespace scope:
 
 ```mermaid
 flowchart TD
-    A[Client calls getInstances] --> B{Namespace provided?}
-    B -->|No| C[Use NamespacedContext.namespace]
-    B -->|Yes| D[Use provided namespace]
-    C --> E[Construct key: ns:svc_itc_idx:serviceId]
-    D --> E
-    E --> F{Is Redis Cluster?}
-    F -->|Yes| G[Apply hash tag via RedisKeys.ofKey]
-    F -->|No| H[Use key as-is]
-    G --> I[EVALSHA discovery_get_instances.lua]
-    H --> I
+    A[Spring client configures namespace] --> B[CoSkyProperties applies RedisKeys.ofKey]
+    B --> C[NamespacedContext stores effective namespace]
+    D[Client calls getInstances] --> E{Namespace provided?}
+    E -->|No| F[Use NamespacedContext.namespace]
+    E -->|Yes| G[Use provided namespace unchanged]
+    C -.-> F
+    F --> H[DiscoveryKeyGenerator interpolates namespace unchanged]
+    G --> H
+    H --> I[EVALSHA discovery_get_instances.lua]
     I --> J[Read instance data from svc_itc keys]
     J --> K[Decode via ServiceInstanceCodec]
     K --> L[Return Flux of ServiceInstance]
@@ -375,7 +374,7 @@ flowchart TD
     style L fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
 ```
 
-<!-- Sources: cosky-core/src/main/kotlin/me/ahoo/cosky/core/NamespacedContext.kt:20-23, cosky-core/src/main/kotlin/me/ahoo/cosky/core/util/RedisKeys.kt:24-31, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceDiscovery.kt:33-54, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:47-49 -->
+<!-- Sources: cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt:38-46, cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyAutoConfiguration.kt:31-35, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/DiscoveryKeyGenerator.kt:51-55, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceDiscovery.kt:33-54 -->
 
 ## Cross-References
 

--- a/wiki/guide/core.md
+++ b/wiki/guide/core.md
@@ -137,6 +137,10 @@ object RedisKeys {
 }
 ```
 
+`RedisKeys` is an explicit utility, not a global key interceptor. `NamespaceService`, `ConfigKeyGenerator`, `DiscoveryKeyGenerator`, and the REST API preserve the namespace string supplied by the caller. `CoSkyProperties` applies `RedisKeys.ofKey(true, namespace)` to the Spring Cloud client's configured namespace, so its resulting value must exactly match the namespace used by the REST API and RBAC bindings.
+
+For Redis Cluster, choose a namespace containing a non-empty hash tag before writing data—for example, `{dev}`, `{prod}`, or `cosky-{system}`. Plain `dev` and tagged `{dev}` generate different physical keys. Converting an existing namespace requires an explicit data migration and rollback plan; changing only configuration makes the old data appear missing.
+
 ### Key Pattern Reference
 
 The following table shows how keys are structured across all domains. Each module contributes its own key generator (`DiscoveryKeyGenerator`, `ConfigKeyGenerator`) that uses the same `{namespace}:` prefix convention:

--- a/wiki/guide/rest-api.md
+++ b/wiki/guide/rest-api.md
@@ -74,6 +74,11 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 | PUT | `/v1/namespaces/{namespace}` | Create a namespace | `setNamespace` | [NamespaceController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L62) |
 | DELETE | `/v1/namespaces/{namespace}` | Remove a namespace | `removeNamespace` | [NamespaceController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L67) |
 
+> [!IMPORTANT]
+> The REST API passes `{namespace}` to namespace storage and Redis key generators exactly as supplied; it does not add or normalize Redis hash tags. In Redis Cluster, use a namespace with a non-empty hash tag, such as `{dev}`, `{prod}`, or `cosky-{system}`. Use that exact value consistently in namespace endpoints, config and service URLs, current-namespace selection, RBAC bindings, and Spring clients.
+>
+> `dev` and `{dev}` are different Redis key prefixes and therefore different data sets. Do not add braces to an existing namespace in place. A change requires key and RBAC inventory, backup, data migration, reconciliation, cutover, and a tested rollback plan.
+
 ### Stat Endpoints
 
 | Method | Path | Description | Controller Method | Source |

--- a/wiki/guide/rest-api.md
+++ b/wiki/guide/rest-api.md
@@ -75,7 +75,7 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 | DELETE | `/v1/namespaces/{namespace}` | Remove a namespace | `removeNamespace` | [NamespaceController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L67) |
 
 > [!IMPORTANT]
-> The REST API passes `{namespace}` to namespace storage and Redis key generators exactly as supplied; it does not add or normalize Redis hash tags. In Redis Cluster, use a namespace with a non-empty hash tag, such as `{dev}`, `{prod}`, or `cosky-{system}`. Use that exact value consistently in namespace endpoints, config and service URLs, current-namespace selection, RBAC bindings, and Spring clients.
+> The REST API passes `{namespace}` to namespace storage and Redis key generators exactly as supplied; it does not add or normalize Redis hash tags. Spring Cloud clients behave differently: `CoSkyProperties` always converts a configured plain namespace such as `dev` to the effective value `{dev}`, regardless of Redis topology. Use an explicit namespace with a non-empty hash tag—even with standalone Redis—such as `{dev}`, `{prod}`, or `cosky-{dev}`. Use that effective tagged value consistently in namespace endpoints, config and service URLs, current-namespace selection, RBAC bindings, and Spring clients.
 >
 > `dev` and `{dev}` are different Redis key prefixes and therefore different data sets. Do not add braces to an existing namespace in place. A change requires key and RBAC inventory, backup, data migration, reconciliation, cutover, and a tested rollback plan.
 

--- a/wiki/zh/guide/core.md
+++ b/wiki/zh/guide/core.md
@@ -137,9 +137,9 @@ object RedisKeys {
 }
 ```
 
-`RedisKeys` 是显式工具，而不是全局 key 拦截器。`NamespaceService`、`ConfigKeyGenerator`、`DiscoveryKeyGenerator` 和 REST API 都会保留调用方传入的 namespace 字符串。`CoSkyProperties` 会对 Spring Cloud 客户端配置的 namespace 调用 `RedisKeys.ofKey(true, namespace)`，因此其结果必须与 REST API 和 RBAC 绑定使用的 namespace 完全一致。
+`RedisKeys` 是显式工具，而不是全局 key 拦截器。`NamespaceService`、`ConfigKeyGenerator`、`DiscoveryKeyGenerator` 和 REST API 都会保留调用方传入的 namespace 字符串。无论 Redis 拓扑如何，`CoSkyProperties` 都会对 Spring Cloud 客户端配置的 namespace 调用 `RedisKeys.ofKey(true, namespace)`，因此其实际生效值必须与 REST API 和 RBAC 绑定使用的 namespace 完全一致。
 
-在 Redis Cluster 中，应在写入数据前确定包含非空 hashtag 的命名空间，例如 `{dev}`、`{prod}` 或 `cosky-{system}`。普通 `dev` 与带 hashtag 的 `{dev}` 会生成不同的物理 key。转换既有命名空间必须制定明确的数据迁移与回滚方案；只修改配置会使旧数据表现为“丢失”。
+所有部署都应在写入数据前确定包含非空 hashtag 的命名空间，例如 `{dev}`、`{prod}` 或 `cosky-{dev}`。Redis Cluster 的多 key Lua 操作要求这样做，同时也能避免 Redis Standalone 下 REST 客户端与 Spring 实际生效的 namespace 不一致。普通 `dev` 与带 hashtag 的 `{dev}` 会生成不同的物理 key。转换既有命名空间必须制定明确的数据迁移与回滚方案；只修改配置会使旧数据表现为“丢失”。
 
 ### 键模式参考
 
@@ -343,20 +343,19 @@ sequenceDiagram
 
 ## 命名空间作用域操作流程
 
-CoSky 中的每个操作都流经命名空间模型。下图说明了典型的服务发现请求如何在命名空间作用域内解析键：
+CoSky 中的每个操作都流经命名空间模型。`CoSkyProperties` 会先包装 Spring Cloud 客户端配置的 namespace，再把它存入默认上下文；显式传入的 namespace 则保持原样。下图说明了典型的服务发现请求如何在命名空间作用域内解析键：
 
 ```mermaid
 flowchart TD
-    A[客户端调用 getInstances] --> B{提供了命名空间？}
-    B -->|否| C[使用 NamespacedContext.namespace]
-    B -->|是| D[使用提供的命名空间]
-    C --> E[构建键: ns:svc_itc_idx:serviceId]
-    D --> E
-    E --> F{是 Redis 集群？}
-    F -->|是| G[通过 RedisKeys.ofKey 应用 hashtag]
-    F -->|否| H[直接使用键]
-    G --> I[EVALSHA discovery_get_instances.lua]
-    H --> I
+    A[Spring 客户端配置 namespace] --> B[CoSkyProperties 调用 RedisKeys.ofKey]
+    B --> C[NamespacedContext 存储实际生效的 namespace]
+    D[客户端调用 getInstances] --> E{提供了命名空间？}
+    E -->|否| F[使用 NamespacedContext.namespace]
+    E -->|是| G[原样使用显式传入的 namespace]
+    C -.-> F
+    F --> H[DiscoveryKeyGenerator 原样拼接 namespace]
+    G --> H
+    H --> I[EVALSHA discovery_get_instances.lua]
     I --> J[从 svc_itc 键读取实例数据]
     J --> K[通过 ServiceInstanceCodec 解码]
     K --> L[返回 Flux of ServiceInstance]
@@ -375,7 +374,7 @@ flowchart TD
     style L fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
 ```
 
-<!-- Sources: cosky-core/src/main/kotlin/me/ahoo/cosky/core/NamespacedContext.kt:20-23, cosky-core/src/main/kotlin/me/ahoo/cosky/core/util/RedisKeys.kt:24-31, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceDiscovery.kt:33-54, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:47-49 -->
+<!-- Sources: cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt:38-46, cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyAutoConfiguration.kt:31-35, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/DiscoveryKeyGenerator.kt:51-55, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceDiscovery.kt:33-54 -->
 
 ## 交叉引用
 

--- a/wiki/zh/guide/core.md
+++ b/wiki/zh/guide/core.md
@@ -137,6 +137,10 @@ object RedisKeys {
 }
 ```
 
+`RedisKeys` 是显式工具，而不是全局 key 拦截器。`NamespaceService`、`ConfigKeyGenerator`、`DiscoveryKeyGenerator` 和 REST API 都会保留调用方传入的 namespace 字符串。`CoSkyProperties` 会对 Spring Cloud 客户端配置的 namespace 调用 `RedisKeys.ofKey(true, namespace)`，因此其结果必须与 REST API 和 RBAC 绑定使用的 namespace 完全一致。
+
+在 Redis Cluster 中，应在写入数据前确定包含非空 hashtag 的命名空间，例如 `{dev}`、`{prod}` 或 `cosky-{system}`。普通 `dev` 与带 hashtag 的 `{dev}` 会生成不同的物理 key。转换既有命名空间必须制定明确的数据迁移与回滚方案；只修改配置会使旧数据表现为“丢失”。
+
 ### 键模式参考
 
 下表展示了所有领域中键的结构方式。每个模块都有自己的键生成器（`DiscoveryKeyGenerator`、`ConfigKeyGenerator`），使用相同的 `{namespace}:` 前缀约定：

--- a/wiki/zh/guide/rest-api.md
+++ b/wiki/zh/guide/rest-api.md
@@ -74,6 +74,11 @@ fun main(args: Array<String>) {
 | PUT | `/v1/namespaces/{namespace}` | 创建命名空间 | `setNamespace` | [NamespaceController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L62) |
 | DELETE | `/v1/namespaces/{namespace}` | 移除命名空间 | `removeNamespace` | [NamespaceController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L67) |
 
+> [!IMPORTANT]
+> REST API 会把 `{namespace}` 原样传给命名空间存储和 Redis key 生成器，不会自动添加或归一化 Redis hashtag。在 Redis Cluster 中，应使用包含非空 hashtag 的命名空间，例如 `{dev}`、`{prod}` 或 `cosky-{system}`。命名空间接口、配置与服务 URL、当前命名空间、RBAC 绑定及 Spring 客户端必须始终使用完全相同的值。
+>
+> `dev` 与 `{dev}` 是不同的 Redis key 前缀，因此对应不同的数据集。不要直接给既有命名空间添加大括号。变更前必须完成 key 与 RBAC 清单、备份、数据迁移、核对、流量切换以及经过验证的回滚方案。
+
 ### 统计端点
 
 | 方法 | 路径 | 描述 | 控制器方法 | 源码 |

--- a/wiki/zh/guide/rest-api.md
+++ b/wiki/zh/guide/rest-api.md
@@ -75,7 +75,7 @@ fun main(args: Array<String>) {
 | DELETE | `/v1/namespaces/{namespace}` | 移除命名空间 | `removeNamespace` | [NamespaceController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/namespace/NamespaceController.kt#L67) |
 
 > [!IMPORTANT]
-> REST API 会把 `{namespace}` 原样传给命名空间存储和 Redis key 生成器，不会自动添加或归一化 Redis hashtag。在 Redis Cluster 中，应使用包含非空 hashtag 的命名空间，例如 `{dev}`、`{prod}` 或 `cosky-{system}`。命名空间接口、配置与服务 URL、当前命名空间、RBAC 绑定及 Spring 客户端必须始终使用完全相同的值。
+> REST API 会把 `{namespace}` 原样传给命名空间存储和 Redis key 生成器，不会自动添加或归一化 Redis hashtag。Spring Cloud 客户端的行为不同：无论 Redis 拓扑如何，`CoSkyProperties` 都会把配置的普通命名空间（如 `dev`）转换为实际生效值 `{dev}`。即使使用 Redis Standalone，也应显式采用包含非空 hashtag 的命名空间，例如 `{dev}`、`{prod}` 或 `cosky-{dev}`。命名空间接口、配置与服务 URL、当前命名空间、RBAC 绑定及 Spring 客户端必须始终使用该实际生效的带 hashtag 值。
 >
 > `dev` 与 `{dev}` 是不同的 Redis key 前缀，因此对应不同的数据集。不要直接给既有命名空间添加大括号。变更前必须完成 key 与 RBAC 清单、备份、数据迁移、核对、流量切换以及经过验证的回滚方案。
 


### PR DESCRIPTION
## Summary
- clarify that REST APIs, namespace storage, and key generators preserve namespace strings exactly as supplied
- document the Redis Cluster requirement for a non-empty hash tag and consistent values across REST, RBAC, and Spring clients
- warn that plain and tagged namespaces are different physical key prefixes and require an explicit migration/rollback plan to convert

## Scope
- documentation only
- no namespace normalization, Lua, key-generator, or Redis data changes
- supersedes the runtime approach in closed PR #976

## Verification
- `git diff --check`