### PR TITLE
Bump version to 5.8.0

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cosky-dashboard",
   "private": true,
-  "version": "5.7.2",
+  "version": "5.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosky
-version=5.7.2
+version=5.8.0
 description=High-performance, low-cost microservice governance platform. Service Discovery and Configuration Service.
 website=https://github.com/Ahoo-Wang/cosky
 issues=https://github.com/Ahoo-Wang/cosky/issues

--- a/wiki/guide/getting-started.md
+++ b/wiki/guide/getting-started.md
@@ -59,7 +59,7 @@ graph LR
 #### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.7.2"
+val coskyVersion = "5.8.0"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
@@ -73,7 +73,7 @@ dependencies {
 
 ```xml
 <properties>
-    <cosky.version>5.7.2</cosky.version>
+    <cosky.version>5.8.0</cosky.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -287,7 +287,7 @@ graph TB
 
 ## References
 
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.7.2`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.8.0`)
 - [CoSkyProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt) -- core configuration properties
 - [CoSkyConfigProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt) -- config starter properties
 - [CoSkyDiscoveryProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt) -- discovery starter properties

--- a/wiki/guide/installation.md
+++ b/wiki/guide/installation.md
@@ -53,7 +53,7 @@ Add CoSky starters to your Spring Cloud application. These are published to Mave
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.7.2"
+val coskyVersion = "5.8.0"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
@@ -73,7 +73,7 @@ dependencies {
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosky.version>5.7.2</cosky.version>
+        <cosky.version>5.8.0</cosky.version>
     </properties>
 
     <dependencyManagement>
@@ -453,7 +453,7 @@ Source: [README.md:206-219](https://github.com/Ahoo-Wang/CoSky/blob/main/README.
 ## References
 
 - [build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/build.gradle.kts) -- root build configuration with JVM 17 toolchain
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.7.2`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.8.0`)
 - [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) -- all module definitions
 - [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml) -- Kubernetes deployment (standalone Redis)
 - [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml) -- Kubernetes deployment (Redis Cluster)

--- a/wiki/guide/onboarding-contributor.md
+++ b/wiki/guide/onboarding-contributor.md
@@ -17,7 +17,7 @@ The name comes from **Co** (configuration) + **Sky** (service discovery). The pr
 
 - Repository: [https://github.com/Ahoo-Wang/CoSky](https://github.com/Ahoo-Wang/CoSky)
 - Group ID: `me.ahoo.cosky`
-- Current version: 5.7.2
+- Current version: 5.8.0
 
 ### Tech Stack
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -257,7 +257,7 @@ graph LR
 #### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.7.2"
+val coskyVersion = "5.8.0"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
@@ -271,7 +271,7 @@ dependencies {
 
 ```xml
 <properties>
-    <cosky.version>5.7.2</cosky.version>
+    <cosky.version>5.8.0</cosky.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -485,7 +485,7 @@ graph TB
 
 ## References
 
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.7.2`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.8.0`)
 - [CoSkyProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt) -- core configuration properties
 - [CoSkyConfigProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt) -- config starter properties
 - [CoSkyDiscoveryProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt) -- discovery starter properties
@@ -544,7 +544,7 @@ Add CoSky starters to your Spring Cloud application. These are published to Mave
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.7.2"
+val coskyVersion = "5.8.0"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
@@ -564,7 +564,7 @@ dependencies {
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosky.version>5.7.2</cosky.version>
+        <cosky.version>5.8.0</cosky.version>
     </properties>
 
     <dependencyManagement>
@@ -944,7 +944,7 @@ Source: [README.md:206-219](https://github.com/Ahoo-Wang/CoSky/blob/main/README.
 ## References
 
 - [build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/build.gradle.kts) -- root build configuration with JVM 17 toolchain
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.7.2`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.8.0`)
 - [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) -- all module definitions
 - [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml) -- Kubernetes deployment (standalone Redis)
 - [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml) -- Kubernetes deployment (Redis Cluster)

--- a/wiki/zh/guide/getting-started.md
+++ b/wiki/zh/guide/getting-started.md
@@ -59,7 +59,7 @@ graph LR
 #### Gradle（Kotlin DSL）
 
 ```kotlin
-val coskyVersion = "5.7.2"
+val coskyVersion = "5.8.0"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
@@ -73,7 +73,7 @@ dependencies {
 
 ```xml
 <properties>
-    <cosky.version>5.7.2</cosky.version>
+    <cosky.version>5.8.0</cosky.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -287,7 +287,7 @@ graph TB
 
 ## 参考
 
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 当前版本（`5.7.2`）
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 当前版本（`5.8.0`）
 - [CoSkyProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt) -- 核心配置属性
 - [CoSkyConfigProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt) -- 配置 Starter 属性
 - [CoSkyDiscoveryProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt) -- 发现 Starter 属性

--- a/wiki/zh/guide/installation.md
+++ b/wiki/zh/guide/installation.md
@@ -53,7 +53,7 @@ flowchart TD
 ### Gradle（Kotlin DSL）
 
 ```kotlin
-val coskyVersion = "5.7.2"
+val coskyVersion = "5.8.0"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
@@ -73,7 +73,7 @@ dependencies {
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosky.version>5.7.2</cosky.version>
+        <cosky.version>5.8.0</cosky.version>
     </properties>
 
     <dependencyManagement>
@@ -453,7 +453,7 @@ REST API 服务器运行后，通过以下地址访问基于 Web 的管理界面
 ## 参考
 
 - [build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/build.gradle.kts) -- 根构建配置，使用 JVM 17 工具链
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 项目版本（`5.7.2`）
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 项目版本（`5.8.0`）
 - [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) -- 所有模块定义
 - [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml) -- Kubernetes 部署（单机 Redis）
 - [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml) -- Kubernetes 部署（Redis 集群）

--- a/wiki/zh/guide/onboarding-contributor.md
+++ b/wiki/zh/guide/onboarding-contributor.md
@@ -17,7 +17,7 @@ CoSky 是一个高性能的微服务治理平台，提供**服务发现**和**�
 
 - 仓库地址：[https://github.com/Ahoo-Wang/CoSky](https://github.com/Ahoo-Wang/CoSky)
 - Group ID：`me.ahoo.cosky`
-- 当前版本：5.7.2
+- 当前版本：5.8.0
 
 ### 技术栈
 


### PR DESCRIPTION
## Summary
- bump Gradle and dashboard versions from 5.7.2 to 5.8.0
- update English, Chinese, and aggregated documentation examples
- prepare the release containing PRs #965–#975 and #977

## Version rationale
This is a minor release rather than a patch because user metadata keys beginning with `_` are now rejected to protect the reserved registry namespace. Existing tagged namespaces and Redis key schemas remain unchanged.

## Verification
- `./gradlew build publishToMavenLocal`
- signed 5.8.0 BOM, libraries, sources, Javadocs, and POMs verified in Maven Local
- `pnpm exec eslint . --no-fix`, `pnpm build`, and 11 dashboard unit tests
- Wiki Mermaid validation (52 files, 0 issues) and VitePress build
- no remaining `5.7.2` references; `git diff --check`