### PR TITLE
docs(wiki): sync documentation with codebase at 5.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ caching strategies and *Redis PubSub*, CoSky achieves real-time cache refreshing
 
 ``` kotlin
     val coskyVersion = "lastVersion";
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config:${coskyVersion}")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery:${coskyVersion}")
-    implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer:3.0.3")
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
+    implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 ```
 
 ### Maven
@@ -65,21 +66,30 @@ caching strategies and *Redis PubSub*, CoSky achieves real-time cache refreshing
         <cosky.version>lastVersion</cosky.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>me.ahoo.cosky</groupId>
+                <artifactId>cosky-bom</artifactId>
+                <version>${cosky.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-config</artifactId>
-            <version>${cosky.version}</version>
+            <artifactId>cosky-spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
-            <version>${cosky.version}</version>
+            <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-loadbalancer</artifactId>
-            <version>3.0.3</version>
         </dependency>
     </dependencies>
 
@@ -114,16 +124,16 @@ Choose from three deployment options based on your environment:
 
 ### 🖥️ Option 1: Standalone Executable
 
-Download the latest release and run directly:
+Build the distribution from source and run directly:
 
 ```shell
-# Download cosky-server
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# Build the distribution (outputs to cosky-rest-api/build/distributions/)
+./gradlew :cosky-rest-api:distTar
 
 # Extract and run
-tar -xvf cosky-server.tar
-cd cosky-server
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-*.tar
+cd cosky-rest-api-*
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 ### 🐳 Option 2: Docker Deployment

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ caching strategies and *Redis PubSub*, CoSky achieves real-time cache refreshing
 
 ``` kotlin
     val coskyVersion = "lastVersion";
+    // cosky-bom: manages CoSky module versions
+    // cosky-dependencies: manages Spring Boot / Spring Cloud / CosID / Simba / CoSec versions
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
@@ -68,9 +71,18 @@ caching strategies and *Redis PubSub*, CoSky achieves real-time cache refreshing
 
     <dependencyManagement>
         <dependencies>
+            <!-- cosky-bom: manages CoSky module versions -->
             <dependency>
                 <groupId>me.ahoo.cosky</groupId>
                 <artifactId>cosky-bom</artifactId>
+                <version>${cosky.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- cosky-dependencies: manages Spring Boot / Spring Cloud / CosID / Simba / CoSec versions -->
+            <dependency>
+                <groupId>me.ahoo.cosky</groupId>
+                <artifactId>cosky-dependencies</artifactId>
                 <version>${cosky.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -107,7 +119,7 @@ spring:
       url: redis://localhost:6379
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-{system}}
+      namespace: ${cosky.namespace:cosky-{default}}
       config:
         config-id: ${spring.application.name}.yaml
     service-registry:
@@ -127,6 +139,9 @@ Choose from three deployment options based on your environment:
 Build the distribution from source and run directly:
 
 ```shell
+# Build the dashboard first (dashboard/dist is gitignored; without this the archive has no web UI)
+cd dashboard && pnpm install && pnpm build && cd ..
+
 # Build the distribution (outputs to cosky-rest-api/build/distributions/)
 ./gradlew :cosky-rest-api:distTar
 

--- a/wiki/guide/architecture.md
+++ b/wiki/guide/architecture.md
@@ -156,7 +156,7 @@ sequenceDiagram
 | Lettuce | latest | Redis client driver (async, reactive) | [cosky-core/build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-core/build.gradle.kts) |
 | Project Reactor | latest | Reactive programming model (Flux, Mono) | [cosky-core/build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-core/build.gradle.kts) |
 | Lua (Redis scripting) | N/A | Atomic multi-step operations | [DiscoveryRedisScripts.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt) |
-| Gradle (Kotlin DSL) | 8.x | Build system | [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) |
+| Gradle (Kotlin DSL) | 9.x | Build system | [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) |
 
 ## Design Principles
 

--- a/wiki/guide/config-consistency.md
+++ b/wiki/guide/config-consistency.md
@@ -136,7 +136,7 @@ The key detail is that the cache stores a `Mono<Config>` that has been `.cache()
 
 ## Cache Invalidation Flow
 
-When any process modifies a configuration, the Lua script publishes a change event on the Redis PubSub channel. Every instance listening on that channel receives the invalidation and refreshes its cache.
+When any process modifies a configuration, the Lua script publishes a change event on the Redis PubSub channel. Every instance listening on that channel receives the invalidation and lazily refreshes its cache.
 
 ```mermaid
 sequenceDiagram
@@ -157,16 +157,14 @@ sequenceDiagram
     PS-->>Listener: Message received
     Listener->>Listener: Parse ConfigChangedEvent
     Listener-->>RCS: onConfigChanged(event)
-    RCS->>Cache: remove old entry
-    RCS->>RDS: getConfig(namespace, configId)
-    RDS->>Redis: HGETALL
-    Redis-->>RDS: new config data
-    RDS-->>RCS: Config
-    RCS->>Cache: put new cached Mono
-    Note over Cache: Next read returns<br>fresh data
+    RCS->>Cache: Overwrite entry with a new cold<br>Mono cached with 1-minute TTL
+    Note over RCS,Cache: No Redis call happens here -- the fetch is deferred<br>until the next getConfig() subscriber arrives
+    Note over Cache: Next read re-executes the fetch<br>and returns fresh data
 ```
 
 <!-- Sources: RedisConsistencyConfigService.kt:68, RedisConfigEventListenerContainer.kt:18, config_set.lua:1 -->
+
+The invalidation path is a single overwrite: `onConfigChanged` replaces the map entry with `delegate.getConfig(...).cache(CONFIG_CACHE_TTL)` -- a cold `Mono` that is never subscribed at invalidation time (hence the `@Suppress("ReactiveStreamsUnusedPublisher")` in the source). The event type (`SET`, `REMOVE`, `ROLLBACK`) is not inspected; all three follow the identical overwrite path, and a removed config simply yields a cached *empty* `Mono`.
 
 ## Event Listener Container
 
@@ -212,28 +210,23 @@ The local cache for each configuration entry goes through a well-defined set of 
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Empty: Initial state
+    [*] --> CachedNoTTL: First getConfig() call<br>entry = getConfig().cache()
 
-    Empty --> Loading: First getConfig() call
-    Loading --> Valid: Redis returns Config data
-    Loading --> Empty: Redis returns null / error
+    CachedNoTTL --> CachedNoTTL: Subsequent getConfig() (cache hit,<br>never expires on its own)
+    CachedNoTTL --> CachedTTL: Any PubSub event (set / remove /<br>rollback) overwrites the entry
 
-    Valid --> Valid: Subsequent getConfig() (cache hit)
-    Valid --> Invalidated: PubSub event received
+    CachedTTL --> CachedTTL: getConfig() within TTL (cache hit)
+    CachedTTL --> Refetching: Cache TTL reached (1 minute)
+    Refetching --> CachedTTL: Next getConfig() re-executes the fetch<br>and caches for another minute
+    CachedTTL --> CachedTTL: Next PubSub event (overwrite)
 
-    Invalidated --> Loading: Re-fetch from Redis
-    Invalidated --> Removed: Event type = REMOVE
-
-    Removed --> Loading: New getConfig() call
-    Removed --> [*]: Config no longer exists
-
-    Valid --> TTLExpired: Cache TTL reached (1 minute)
-    TTLExpired --> Loading: Re-fetch from Redis
+    CachedNoTTL --> [*]: Listener terminated<br>(entry removed from map)
+    CachedTTL --> [*]: Listener terminated<br>(entry removed from map)
 ```
 
-<!-- Sources: RedisConsistencyConfigService.kt:40, RedisConsistencyConfigService.kt:46 -->
+<!-- Sources: RedisConsistencyConfigService.kt:40, RedisConsistencyConfigService.kt:46, RedisConsistencyConfigService.kt:57, RedisConsistencyConfigService.kt:68 -->
 
-The `CONFIG_CACHE_TTL` is set to `Duration.ofMinutes(1)`. When a cache entry is refreshed due to a PubSub invalidation event, the new `Mono` is created with `.cache(CONFIG_CACHE_TTL)`, ensuring that even without further invalidation events, stale data is eventually evicted.
+The `CONFIG_CACHE_TTL` is set to `Duration.ofMinutes(1)`, but it applies **only to entries written by the PubSub refresh path** (`onConfigChanged` uses `.cache(CONFIG_CACHE_TTL)`). The initial cache entry, created on the first `getConfig()` call, uses plain `.cache()` with **no TTL** and never expires on its own. If the PubSub listener terminates, its `doFinally` hook removes the entry from the map, so the next `getConfig()` re-creates the entry and re-subscribes.
 
 Source: [RedisConsistencyConfigService.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt#L40)
 
@@ -281,7 +274,9 @@ Each cached configuration entry occupies memory in the JVM heap for the `Concurr
 
 ### PubSub Reliability
 
-Redis PubSub is a fire-and-forget protocol -- if an instance is temporarily disconnected (network blip, GC pause), it will miss invalidation messages. CoSky mitigates this through the `CONFIG_CACHE_TTL` of 1 minute: even if an invalidation event is missed, the cache entry will expire and be re-fetched from Redis within 60 seconds.
+Redis PubSub is a fire-and-forget protocol -- if an instance is temporarily disconnected (network blip, GC pause), it will miss invalidation messages. The `CONFIG_CACHE_TTL` of 1 minute bounds this staleness **only for entries that have already been refreshed by a previous invalidation event**: those entries are re-fetched from Redis at most 60 seconds after their last refresh. The initial cache entry, however, is created with plain `.cache()` (no TTL) and never expires on its own -- if the very first invalidation event for a config is missed, that entry keeps serving stale data until a later event arrives, the listener terminates (which evicts the entry), or the process restarts.
+
+Source: [RedisConsistencyConfigService.kt:64-76](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt#L64)
 
 ### Delegation Pattern
 

--- a/wiki/guide/config-service.md
+++ b/wiki/guide/config-service.md
@@ -284,7 +284,7 @@ spring:
       url: redis://localhost:6379
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-{system}}
+      namespace: ${cosky.namespace:cosky-{default}}
       config:
         config-id: ${spring.application.name}.yaml
     service-registry:
@@ -298,10 +298,10 @@ logging:
 | Config Property | Description | Example |
 |---|---|---|
 | `spring.data.redis.url` | Redis connection URL | `redis://localhost:6379` |
-| `spring.cloud.cosky.namespace` | Namespace for config isolation | `cosky-{system}` |
+| `spring.cloud.cosky.namespace` | Namespace for config isolation | `cosky-{default}` |
 | `spring.cloud.cosky.config.config-id` | The configId to load (typically `{app}.yaml`) | `order-service.yaml` |
 
-Source: [README.md:89](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L89)
+Source: [README.md:111](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L111)
 
 ## Rollback Mechanism
 

--- a/wiki/guide/config-service.md
+++ b/wiki/guide/config-service.md
@@ -284,15 +284,21 @@ spring:
       url: redis://localhost:6379
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-production}
+      namespace: ${cosky.namespace:cosky-{system}}
       config:
         config-id: ${spring.application.name}.yaml
+    service-registry:
+      auto-registration:
+        enabled: ${cosky.auto-registry:true}
+logging:
+  file:
+    name: logs/${spring.application.name}.log
 ```
 
 | Config Property | Description | Example |
 |---|---|---|
 | `spring.data.redis.url` | Redis connection URL | `redis://localhost:6379` |
-| `spring.cloud.cosky.namespace` | Namespace for config isolation | `cosky-production` |
+| `spring.cloud.cosky.namespace` | Namespace for config isolation | `cosky-{system}` |
 | `spring.cloud.cosky.config.config-id` | The configId to load (typically `{app}.yaml`) | `order-service.yaml` |
 
 Source: [README.md:89](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L89)

--- a/wiki/guide/dashboard.md
+++ b/wiki/guide/dashboard.md
@@ -4,13 +4,13 @@ title: Dashboard
 
 # Dashboard
 
-The CoSky Dashboard is a modern single-page application built with React 19, TypeScript, and Ant Design 6. It provides a visual management interface for all CoSky capabilities: service monitoring, configuration management, service topology visualization, RBAC administration, user management, and audit log review. The dashboard is served directly by the REST API server as static assets and communicates with the backend exclusively through the CoSky REST API.
+The CoSky Dashboard is a modern single-page application built with React 19, TypeScript, Radix UI, and shadcn/ui (styled with Tailwind CSS 4). It provides a visual management interface for all CoSky capabilities: service monitoring, configuration management, service topology visualization, RBAC administration, user management, and audit log review. The dashboard is served directly by the REST API server as static assets and communicates with the backend exclusively through the CoSky REST API.
 
 ## At a Glance
 
 | Aspect | Detail | Key File | Source |
 |--------|--------|----------|--------|
-| Frontend app | React 19 SPA with Ant Design 6 | `dashboard/package.json` | [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json) |
+| Frontend app | React 19 SPA with Radix UI + shadcn/ui | `dashboard/package.json` | [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json) |
 | SPA route serving | Serves `index.html` for all dashboard routes | `DashboardConfiguration.kt` | [cosky-rest-api/.../DashboardConfiguration.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/dashboard/DashboardConfiguration.kt#L30) |
 | API client | Auto-generated from OpenAPI spec | `dashboard/src/generated/` | [dashboard/package.json:12](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json#L12) |
 
@@ -18,18 +18,23 @@ The CoSky Dashboard is a modern single-page application built with React 19, Typ
 
 | Technology | Version | Purpose |
 |-----------|---------|---------|
-| React | 19.2.6 | UI framework |
+| React | 19.2.6 | UI framework (with React Compiler) |
 | TypeScript | ~6.0.3 | Type-safe development |
 | Vite | 8.0.16 | Build tool and dev server |
-| Ant Design | 6.3.7 | UI component library |
+| Radix UI | 1.6.7 | Headless UI primitives |
+| shadcn/ui | 4.18.0 | Vendored component pattern (`src/components/ui/`) |
+| Tailwind CSS | 4.3.3 | Utility-first styling |
+| lucide-react | 1.31.0 | Icon set |
+| sonner | 2.0.8 | Toast notifications |
 | React Router DOM | 7.15.1 | Client-side routing |
 | @xyflow/react | 12.10.2 | Service topology visualization |
-| Monaco Editor | 0.55.1 | Configuration text editor |
+| Monaco Editor | 0.55.1 (via @monaco-editor/react 4.7.0) | Configuration text editor |
 | @ahoo-wang/fetcher | 3.16.10 | HTTP client with CoSec auth |
 | @ahoo-wang/fetcher-react | 3.16.10 | React hooks for API calls |
 | @ahoo-wang/fetcher-cosec | 3.16.10 | CoSec token refresh integration |
-| @ahoo-wang/fetcher-viewer | 3.16.10 | Data table and filter components |
+| @ahoo-wang/fetcher-storage | 3.16.10 | Token storage |
 | @ahoo-wang/fetcher-generator | 3.16.10 | OpenAPI code generation |
+| Playwright | 1.62.1 | Unit and end-to-end UI testing |
 
 Source: [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json)
 
@@ -73,13 +78,17 @@ The role management page allows administrators to create roles and assign namesp
 
 ![User](/dashboard-user.png)
 
-User management supports creating users, assigning roles, changing passwords, and unlocking locked accounts.
+User management supports creating users, assigning roles, changing passwords, and locking/unlocking accounts. Each row shows a `locked` badge reflecting the account state returned by the API. A manually locked user can no longer sign in or refresh tokens until an administrator unlocks the account; the root user (`cosky`) cannot be locked. See [Security & RBAC](/guide/security-rbac#login-lockout-mechanism) for the lockout semantics.
 
 ### Audit Log
 
 ![Audit Log](/dashboard-audit-log.png)
 
-The audit log page displays a paginated list of all audited operations with operator, IP, path, action, status, and timestamp columns.
+The audit log page displays a paginated list of all audited operations with operator, IP, resource, action, status, and timestamp columns, and can export the audit log as a CSV file (`GET /v1/audit-log/export`).
+
+### Navigation Search
+
+The sidebar includes a keyboard-first navigation search. Press `/` anywhere outside an input field to focus it, filter pages by name or description, move with `ArrowUp`/`ArrowDown`, and jump with `Enter`.
 
 ### Login
 
@@ -103,10 +112,10 @@ flowchart TD
     end
 
     subgraph "Redis"
-        UserRedis["User Index<br>system:user_idx"]
+        UserRedis["User Index<br>cosky-{system}:user_idx"]
         ConfigRedis["Configs<br>Namespaced keys"]
         ServiceRedis["Services<br>Namespaced keys"]
-        AuditRedis["Audit Log<br>system:audit:log"]
+        AuditRedis["Audit Log<br>cosky-{system}:audit:log"]
     end
 
     SPA -->|"HTML/JS/CSS"| DashboardConfig

--- a/wiki/guide/deployment-kubernetes.md
+++ b/wiki/guide/deployment-kubernetes.md
@@ -76,6 +76,10 @@ spec:
 
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
+::: tip Image tag
+The in-repo manifests pin the image tag to `5.3.5` ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)), while the current release is `5.7.2` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). Override the image (e.g. `ahoowang/cosky:latest` on Docker Hub) to run the latest version.
+:::
+
 ## Clustered Redis Deployment
 
 For production environments with Redis Cluster, use the cluster manifest which reads connection details from a Kubernetes Secret:

--- a/wiki/guide/deployment-kubernetes.md
+++ b/wiki/guide/deployment-kubernetes.md
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           ports:
             - name: http
               containerPort: 8080
@@ -77,7 +77,7 @@ spec:
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
 ::: tip Image tag
-The in-repo manifests pin the image tag to `5.3.5` ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)), while the current release is `5.7.2` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). Override the image (e.g. `ahoowang/cosky:latest` on Docker Hub) to run the latest version.
+The manifests below use the current release `5.7.2` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). The in-repo manifests ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)) still pin the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` on Docker Hub.
 :::
 
 ## Clustered Redis Deployment
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           env:
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:

--- a/wiki/guide/deployment-standalone.md
+++ b/wiki/guide/deployment-standalone.md
@@ -13,6 +13,10 @@ The standalone deployment option lets you run CoSky directly on a host machine w
 GitHub releases do not publish a pre-built tarball, so build the standalone distribution from source (JDK 17+ required):
 
 ```bash
+# Build the dashboard first (dashboard/dist is gitignored;
+# without this step the archive has no web UI)
+cd dashboard && pnpm install && pnpm build && cd ..
+
 # Build the distribution tarball
 ./gradlew :cosky-rest-api:distTar
 
@@ -23,7 +27,7 @@ tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
 cd cosky-rest-api-5.7.2
 ```
 
-The distribution bundles the dashboard static files from `dashboard/dist` into `ui/`. If that directory is missing, build the dashboard first with `cd dashboard && pnpm install && pnpm build`.
+The distribution bundles the dashboard static files from `dashboard/dist` into `ui/`.
 
 The extracted directory structure contains:
 

--- a/wiki/guide/deployment-standalone.md
+++ b/wiki/guide/deployment-standalone.md
@@ -8,32 +8,33 @@ title: "Standalone Deployment"
 
 The standalone deployment option lets you run CoSky directly on a host machine without Docker or Kubernetes. This approach is ideal for development environments, small-scale deployments, or environments where container runtimes are not available. The standalone distribution packages CoSky as a self-contained application with startup scripts, configuration files, and the built-in dashboard UI.
 
-## Download and Extract
+## Build and Extract
 
-Download the latest release tarball and extract it:
+GitHub releases do not publish a pre-built tarball, so build the standalone distribution from source (JDK 17+ required):
 
 ```bash
-# Download the latest release
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# Build the distribution tarball
+./gradlew :cosky-rest-api:distTar
 
 # Extract
-tar -xvf cosky-server.tar
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
 
 # Enter the directory
-cd cosky-server
+cd cosky-rest-api-5.7.2
 ```
+
+The distribution bundles the dashboard static files from `dashboard/dist` into `ui/`. If that directory is missing, build the dashboard first with `cd dashboard && pnpm install && pnpm build`.
 
 The extracted directory structure contains:
 
 ```
-cosky-server/
+cosky-rest-api-5.7.2/
   bin/
-    cosky              # Startup script (Unix)
+    cosky-rest-api     # Startup script (Unix)
   config/
     application.yaml   # Application configuration
     bootstrap.yaml     # Bootstrap configuration
-  dashboard/
-    dist/              # Dashboard UI static files
+  ui/                  # Dashboard UI static files
   lib/
     *.jar              # Runtime dependencies
 ```
@@ -43,7 +44,7 @@ cosky-server/
 Start CoSky with the required Redis connection parameter:
 
 ```bash
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 All Spring Boot properties can be passed as command-line arguments using the `--property=value` format. Alternatively, set them as environment variables or edit the configuration files directly.
@@ -60,7 +61,7 @@ flowchart TD
     C -->|"Yes"| E["Kubernetes Deployment"]
     C -->|"No"| F["Docker / Docker Compose"]
     D --> G{"JDK 17+<br>installed?"}
-    G -->|"Yes"| H["Download tarball<br>bin/cosky"]
+    G -->|"Yes"| H["Build tarball<br>bin/cosky-rest-api"]
     G -->|"No"| I["Install JDK 17+"]
     I --> H
     H --> J{"Redis<br>available?"}
@@ -104,7 +105,7 @@ spring:
           weight: 8
   web:
     resources:
-      static-locations: file:./dashboard/dist/
+      static-locations: file:./ui/
 cosky:
   security:
     enabled: true
@@ -203,7 +204,7 @@ sequenceDiagram
     participant R as Redis
     participant US as cosky (super user)
 
-    OS->>JVM: bin/cosky --server.port=8080
+    OS->>JVM: bin/cosky-rest-api --server.port=8080
     JVM->>SB: start application context
     SB->>SB: load bootstrap.yaml
     SB->>SB: resolve application name: cosky-rest-api
@@ -266,7 +267,7 @@ To pass JVM options through the startup script, set the `JAVA_OPTS` environment 
 
 ```bash
 export JAVA_OPTS="-Xms512M -Xmx512M -XX:+UseZGC"
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 ## Service Discovery and Self-Registration
@@ -310,7 +311,7 @@ logging:
 To change the log location, override the `logging.file.name` property:
 
 ```bash
-bin/cosky --logging.file.name=/var/log/cosky/cosky.log
+bin/cosky-rest-api --logging.file.name=/var/log/cosky/cosky.log
 ```
 
 ## Related Pages

--- a/wiki/guide/getting-started.md
+++ b/wiki/guide/getting-started.md
@@ -62,9 +62,9 @@ graph LR
 val coskyVersion = "5.7.2"
 
 dependencies {
-    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery")
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 }
 ```
@@ -79,7 +79,7 @@ dependencies {
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>cosky-dependencies</artifactId>
+            <artifactId>cosky-bom</artifactId>
             <version>${cosky.version}</version>
             <type>pom</type>
             <scope>import</scope>
@@ -89,11 +89,11 @@ dependencies {
 <dependencies>
     <dependency>
         <groupId>me.ahoo.cosky</groupId>
-        <artifactId>spring-cloud-starter-cosky-config</artifactId>
+        <artifactId>cosky-spring-cloud-starter-config</artifactId>
     </dependency>
     <dependency>
         <groupId>me.ahoo.cosky</groupId>
-        <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
+        <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
     </dependency>
     <dependency>
         <groupId>org.springframework.cloud</groupId>
@@ -106,27 +106,25 @@ Current version defined in [gradle.properties:14](https://github.com/Ahoo-Wang/C
 
 ### Step 2: Configure Bootstrap
 
-Create `src/main/resources/bootstrap.yaml`:
+Create `src/main/resources/bootstrap.yaml`. Shown below is the configuration used by the bundled example provider:
 
 ```yaml
+server:
+  port: 8099
 spring:
   application:
-    name: ${service.name:my-service}
-  data:
-    redis:
-      url: redis://localhost:6379
+    name: ${service.name:example-provider}
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-{default}}
+      namespace: ${cosky.namespace:dev}
       config:
         config-id: ${spring.application.name}.yaml
-    service-registry:
-      auto-registration:
-        enabled: ${cosky.auto-registry:true}
 logging:
   file:
     name: logs/${spring.application.name}.log
 ```
+
+The example relies on Spring Boot's default Redis connection (`localhost:6379`); set `spring.data.redis.url` explicitly if your Redis instance runs elsewhere. Service auto-registration is enabled by default (`spring.cloud.service-registry.auto-registration.enabled`).
 
 | Property | Default | Description |
 |----------|---------|-------------|
@@ -134,7 +132,7 @@ logging:
 | `spring.cloud.cosky.namespace` | `cosky-{default}` | Namespace for service/config isolation ([CoSkyProperties.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt#L30)) |
 | `spring.cloud.cosky.config.config-id` | `${spring.application.name}.yaml` | Config file ID to load ([CoSkyConfigAutoConfiguration.kt:48](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L48)) |
 | `spring.cloud.service-registry.auto-registration.enabled` | `true` | Auto-register service on startup |
-| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension for config lookup ([CoSkyConfigProperties.kt:27](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L27)) |
+| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension for config lookup ([CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28)) |
 
 Source: [examples/cosky-service-provider/src/main/resources/bootstrap.yaml](https://github.com/Ahoo-Wang/CoSky/blob/main/examples/cosky-service-provider/src/main/resources/bootstrap.yaml)
 

--- a/wiki/guide/getting-started.md
+++ b/wiki/guide/getting-started.md
@@ -63,6 +63,7 @@ val coskyVersion = "5.7.2"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
@@ -80,6 +81,13 @@ dependencies {
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
             <artifactId>cosky-bom</artifactId>
+            <version>${cosky.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.ahoo.cosky</groupId>
+            <artifactId>cosky-dependencies</artifactId>
             <version>${cosky.version}</version>
             <type>pom</type>
             <scope>import</scope>

--- a/wiki/guide/index.md
+++ b/wiki/guide/index.md
@@ -12,7 +12,7 @@ description: Explore CoSky's architecture, features, and documentation for high-
 | Feature | Description | Source |
 |---------|-------------|--------|
 | **Service Discovery** | Register, discover, and manage service instances with automatic renewal via client heartbeat. Supports weighted load balancing and service topology. | [ServiceRegistry.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceRegistry.kt#L24), [ServiceDiscovery.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceDiscovery.kt#L24) |
-| **Configuration Management** | Dynamic configuration with version history (last 10 versions), rollback support, and file import/export. Changes propagate instantly via Redis PubSub. | [ConfigService.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigService.kt#L24), [ConfigRollback.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigRollback.kt#L24) |
+| **Configuration Management** | Dynamic configuration with version history and rollback support, plus file import/export. Changes propagate instantly via Redis PubSub. | [ConfigService.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigService.kt#L24), [ConfigRollback.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigRollback.kt#L24) |
 | **Consistency Caching** | Local process cache kept in sync via Redis PubSub, achieving 250x-800x performance improvement over direct Redis reads. | [RedisConsistencyConfigService](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt), [ConsistencyRedisServiceDiscovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/ConsistencyRedisServiceDiscovery.kt) |
 | **Spring Cloud Integration** | Drop-in starters for both config and discovery. Auto-configures via Spring Boot `@AutoConfiguration`. | [CoSkyConfigAutoConfiguration.kt:43](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L43), [CoSkyDiscoveryAutoConfiguration.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L47) |
 | **Weighted Load Balancing** | Binary weight random load balancer integrated with service discovery for efficient instance selection. | [CoSkyDiscoveryAutoConfiguration.kt:105](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L105) |
@@ -27,8 +27,8 @@ description: Explore CoSky's architecture, features, and documentation for high-
 graph TB
     subgraph Applications["Applications"]
         style Applications fill:#161b22,stroke:#30363d,color:#e6edf3
-        A["Spring Boot App 1"] --> |uses| SC_C["spring-cloud-starter-cosky-config"]
-        A --> |uses| SC_D["spring-cloud-starter-cosky-discovery"]
+        A["Spring Boot App 1"] --> |uses| SC_C["cosky-spring-cloud-starter-config"]
+        A --> |uses| SC_D["cosky-spring-cloud-starter-discovery"]
         B["Spring Boot App 2"] --> |uses| SC_C
         B --> |uses| SC_D
     end
@@ -79,8 +79,8 @@ graph LR
         style Modules fill:#161b22,stroke:#30363d,color:#e6edf3
         CORE["cosky-core"] --> CONFIG["cosky-config"]
         CORE --> DISCOVERY["cosky-discovery"]
-        CONFIG --> SCC["spring-cloud-starter-cosky-config"]
-        DISCOVERY --> SCD["spring-cloud-starter-cosky-discovery"]
+        CONFIG --> SCC["cosky-spring-cloud-starter-config"]
+        DISCOVERY --> SCD["cosky-spring-cloud-starter-discovery"]
         SCC --> REST["cosky-rest-api"]
         SCD --> REST
         SC_CORE["cosky-spring-cloud-core"] --> SCC

--- a/wiki/guide/installation.md
+++ b/wiki/guide/installation.md
@@ -57,6 +57,7 @@ val coskyVersion = "5.7.2"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
@@ -85,6 +86,13 @@ dependencies {
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>me.ahoo.cosky</groupId>
+                <artifactId>cosky-dependencies</artifactId>
+                <version>${cosky.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -105,7 +113,7 @@ dependencies {
 </project>
 ```
 
-Source: [gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14), [README.md:46-87](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L46-L87)
+Source: [gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14), [README.md:46-108](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L46-L108)
 
 ### Available Artifacts
 
@@ -113,7 +121,8 @@ Source: [gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/grad
 |----------|---------|--------|
 | `cosky-spring-cloud-starter-config` | Spring Cloud config loading and real-time refresh | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
 | `cosky-spring-cloud-starter-discovery` | Spring Cloud service registration and discovery | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
-| `cosky-bom` | Bill of Materials for dependency version management | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
+| `cosky-bom` | Bill of Materials — manages CoSky module versions | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
+| `cosky-dependencies` | Version catalog — manages Spring Boot / Spring Cloud / CosID / Simba / CoSec versions (required for the versionless `spring-cloud-starter-loadbalancer`) | [cosky-dependencies](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-dependencies) |
 
 ## REST API Server Installation
 
@@ -148,7 +157,7 @@ On first startup, CoSky initializes the super user and prints the generated pass
 
 To reinitialize the password, set `enforce-init-super-user: true` in your configuration.
 
-Source: [cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44), [cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13), [README.md:242](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L242)
+Source: [cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44), [cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13), [README.md:267](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L267)
 
 ### Option 2: Docker
 
@@ -185,7 +194,7 @@ services:
       - redis
 ```
 
-Source: [README.md:132-137](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L132-L137)
+Source: [README.md:159-163](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L159-L163)
 
 ### Option 3: Kubernetes
 
@@ -220,7 +229,7 @@ spec:
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           startupProbe:
             httpGet:
               port: http
@@ -255,7 +264,7 @@ spec:
           name: volume-localtime
 ```
 
-> **Note:** The in-repo manifest pins the image tag to `5.3.5` while the current release is `5.7.2`. You may want to override the image tag — for example `ahoowang/cosky:5.7.2` from Docker Hub or the equivalent tag on another registry.
+> **Note:** The example above uses the current release `5.7.2`. The in-repo manifest ([k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)) still pins the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` from Docker Hub.
 
 Source: [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -304,7 +313,7 @@ spec:
               value: 30s
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           startupProbe:
             httpGet:
               port: http
@@ -496,7 +505,7 @@ The dashboard provides:
 - Service topology visualization
 - Import/export functionality (including Nacos migration)
 
-Source: [README.md:206-219](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L206-L219)
+Source: [README.md:238-246](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L238-L246)
 
 ## References
 

--- a/wiki/guide/installation.md
+++ b/wiki/guide/installation.md
@@ -56,9 +56,9 @@ Add CoSky starters to your Spring Cloud application. These are published to Mave
 val coskyVersion = "5.7.2"
 
 dependencies {
-    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery")
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 }
 ```
@@ -80,7 +80,7 @@ dependencies {
         <dependencies>
             <dependency>
                 <groupId>me.ahoo.cosky</groupId>
-                <artifactId>cosky-dependencies</artifactId>
+                <artifactId>cosky-bom</artifactId>
                 <version>${cosky.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -91,11 +91,11 @@ dependencies {
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-config</artifactId>
+            <artifactId>cosky-spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
+            <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -111,8 +111,8 @@ Source: [gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/grad
 
 | Artifact | Purpose | Module |
 |----------|---------|--------|
-| `spring-cloud-starter-cosky-config` | Spring Cloud config loading and real-time refresh | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
-| `spring-cloud-starter-cosky-discovery` | Spring Cloud service registration and discovery | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
+| `cosky-spring-cloud-starter-config` | Spring Cloud config loading and real-time refresh | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
+| `cosky-spring-cloud-starter-discovery` | Spring Cloud service registration and discovery | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
 | `cosky-bom` | Bill of Materials for dependency version management | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
 
 ## REST API Server Installation
@@ -121,19 +121,24 @@ The REST API server provides a management dashboard, REST endpoints, security (R
 
 ### Option 1: Standalone JAR
 
-Download the latest release and run directly:
+GitHub releases do not publish prebuilt archives, so build the server distribution from source (JDK 17 required):
 
 ```bash
-# Download cosky-server
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# (Optional) Build the dashboard first so the web UI is bundled into the distribution
+cd dashboard && pnpm install && pnpm build && cd ..
 
-# Extract
-tar -xvf cosky-server.tar
-cd cosky-server
+# Build the distribution archive
+./gradlew :cosky-rest-api:distTar
+
+# Extract (the archive name includes the version)
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
+cd cosky-rest-api-5.7.2
 
 # Run with Redis connection
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
+
+The distribution contains `bin/` start scripts, `lib/` dependencies, `config/` configuration files, and `ui/` with the dashboard static resources (served via `spring.web.resources.static-locations: file:./ui/`).
 
 On first startup, CoSky initializes the super user and prints the generated password to the console:
 
@@ -143,7 +148,7 @@ On first startup, CoSky initializes the super user and prints the generated pass
 
 To reinitialize the password, set `enforce-init-super-user: true` in your configuration.
 
-Source: [README.md:119-127](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L119-L127)
+Source: [cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44), [cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13), [README.md:242](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L242)
 
 ### Option 2: Docker
 
@@ -204,20 +209,18 @@ spec:
     metadata:
       labels:
         app: cosky
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
-        - name: cosky
-          image: ahoowang/cosky:latest
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-          env:
+        - env:
             - name: SPRING_DATA_REDIS_HOST
               value: redis-uri:6379
             - name: SPRING_DATA_REDIS_PASSWORD
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
           startupProbe:
             httpGet:
               port: http
@@ -230,21 +233,29 @@ spec:
             httpGet:
               port: http
               path: /actuator/health/liveness
+          name: cosky
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
           resources:
-            requests:
-              cpu: 250m
-              memory: 1024Mi
             limits:
               cpu: "1"
               memory: 1280Mi
+            requests:
+              cpu: 250m
+              memory: 1024Mi
           volumeMounts:
-            - name: volume-localtime
-              mountPath: /etc/localtime
+            - mountPath: /etc/localtime
+              name: volume-localtime
       volumes:
-        - name: volume-localtime
-          hostPath:
+        - hostPath:
             path: /etc/localtime
+            type: ""
+          name: volume-localtime
 ```
+
+> **Note:** The in-repo manifest pins the image tag to `5.3.5` while the current release is `5.7.2`. You may want to override the image tag — for example `ahoowang/cosky:5.7.2` from Docker Hub or the equivalent tag on another registry.
 
 Source: [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -268,11 +279,13 @@ spec:
     metadata:
       labels:
         app: cosky
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
-        - name: cosky
-          image: ahoowang/cosky:latest
-          env:
+        - env:
+            - name: LANG
+              value: C.utf8
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:
                 secretKeyRef:
@@ -289,6 +302,41 @@ spec:
               value: "true"
             - name: SPRING_DATA_REDIS_LETTUCE_CLUSTER_REFRESH_PERIOD
               value: 30s
+            - name: TZ
+              value: Asia/Shanghai
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          startupProbe:
+            httpGet:
+              port: http
+              path: /actuator/health
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /actuator/health/readiness
+          livenessProbe:
+            httpGet:
+              port: http
+              path: /actuator/health/liveness
+          name: cosky
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1280Mi
+            requests:
+              cpu: 250m
+              memory: 1024Mi
+          volumeMounts:
+            - mountPath: /etc/localtime
+              name: volume-localtime
+      volumes:
+        - hostPath:
+            path: /etc/localtime
+            type: ""
+          name: volume-localtime
 ```
 
 Source: [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml)
@@ -365,8 +413,8 @@ Key configuration properties for CoSky:
 | `spring.cloud.cosky.namespace` | `cosky-{default}` | Isolation namespace for services and configs | [CoSkyProperties.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt#L30) |
 | `spring.cloud.cosky.config.enabled` | `true` | Enable config loading from Redis | [CoSkyConfigProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L26) |
 | `spring.cloud.cosky.config.config-id` | `${spring.application.name}.yaml` | Config file ID to load | [CoSkyConfigAutoConfiguration.kt:48](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L48) |
-| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension | [CoSkyConfigProperties.kt:27](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L27) |
-| `spring.cloud.cosky.config.timeout` | `2s` | Timeout for config loading | [CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28) |
+| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension | [CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28) |
+| `spring.cloud.cosky.config.timeout` | `2s` | Timeout for config loading | [CoSkyConfigProperties.kt:29](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L29) |
 | `spring.cloud.cosky.discovery.enabled` | `true` | Enable service discovery | [CoSkyDiscoveryProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt#L26) |
 | `spring.cloud.cosky.discovery.timeout` | `2s` | Timeout for discovery operations | [CoSkyDiscoveryProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt#L28) |
 | `spring.cloud.service-registry.auto-registration.enabled` | `true` | Auto-register service on startup | [bootstrap.yaml:9](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/bootstrap.yaml#L9) |
@@ -381,7 +429,7 @@ When using the discovery starter, service instances have configurable TTL and he
 |----------|---------|-------------|--------|
 | Instance TTL | `60s` | How long an instance lives before being considered expired | [RegistryProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RegistryProperties.kt#L26) |
 | Renew period | `10s` | How often the instance sends a heartbeat to renew its TTL | [RenewProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L28) |
-| Renew initial delay | `1s` | Delay before the first heartbeat after registration | [RenewProperties.kt:25](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L25) |
+| Renew initial delay | `1s` | Delay before the first heartbeat after registration | [RenewProperties.kt:23](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L23) |
 
 ```mermaid
 %%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#2d333b','primaryBorderColor':'#6d5dfc','primaryTextColor':'#e6edf3','lineColor':'#8b949e','secondaryColor':'#161b22','tertiaryColor':'#161b22'}}}%%

--- a/wiki/guide/load-balancers.md
+++ b/wiki/guide/load-balancers.md
@@ -269,7 +269,7 @@ val instance = Instance.asInstance(
     metadata = mapOf("version" to "v2")
 )
 
-serviceRegistry.register(instance = instance).block()
+serviceRegistry.register(serviceInstance = instance).block()
 ```
 
 The weight is stored in the Redis hash under the `weight` field and decoded by `ServiceInstanceCodec` ([ServiceInstanceCodec.kt:32](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt#L32)).

--- a/wiki/guide/rest-api.md
+++ b/wiki/guide/rest-api.md
@@ -92,12 +92,13 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 
 | Method | Path | Description | Controller Method | Source |
 |--------|------|-------------|-------------------|--------|
-| GET | `/v1/users` | List all users with roles | `query` | [UserController.kt:42](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L42) |
-| POST | `/v1/users/{username}` | Add a new user | `addUser` | [UserController.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L52) |
-| DELETE | `/v1/users/{username}` | Remove a user | `removeUser` | [UserController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L62) |
-| PATCH | `/v1/users/{username}/password` | Change password | `changePwd` | [UserController.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L47) |
-| PATCH | `/v1/users/{username}/role` | Bind roles to user | `bindRole` | [UserController.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L57) |
-| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | `unlock` | [UserController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L67) |
+| GET | `/v1/users` | List all users with roles | `query` | [UserController.kt:44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L44) |
+| POST | `/v1/users/{username}` | Add a new user | `addUser` | [UserController.kt:54](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L54) |
+| DELETE | `/v1/users/{username}` | Remove a user | `removeUser` | [UserController.kt:64](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L64) |
+| PATCH | `/v1/users/{username}/password` | Change password | `changePwd` | [UserController.kt:49](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L49) |
+| PATCH | `/v1/users/{username}/role` | Bind roles to user | `bindRole` | [UserController.kt:59](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L59) |
+| PUT | `/v1/users/{username}/lock` | Lock a user (manual lock; root user cannot be locked) | `lock` | [UserController.kt:68](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L68) |
+| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | `unlock` | [UserController.kt:74](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L74) |
 
 ### Role Endpoints
 
@@ -112,7 +113,8 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 
 | Method | Path | Description | Controller Method | Source |
 |--------|------|-------------|-------------------|--------|
-| GET | `/v1/audit-log` | Query audit logs | `queryLog` | [AuditLogController.kt:32](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L32) |
+| GET | `/v1/audit-log` | Query audit logs | `queryLog` | [AuditLogController.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L40) |
+| GET | `/v1/audit-log/export` | Export audit log as CSV | `exportLog` | [AuditLogController.kt:51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L51) |
 
 ## Sequence Diagrams
 
@@ -239,12 +241,12 @@ cosky:
     enabled: true                    # Enable/disable security
     audit-log:
       action: write                  # Audit log filter: "write", "read", or "rw"
-    enforce-init-super-user: false   # Force re-initialize super user on startup
+    enforce-init-super-user: ${cosky.super.init:false}   # Force re-initialize super user on startup
 
 cosec:
   jwt:
     algorithm: hmac256               # JWT signing algorithm
-    secret: ${cosky.security.key}    # JWT secret key
+    secret: ${cosky.security.key:FyN0Igd80Gas3stTavArGKOYnS9uLWGA$}    # JWT secret key
     token-validity:
       access: 15m                    # Access token TTL
       refresh: 3H                    # Refresh token TTL

--- a/wiki/guide/security-rbac.md
+++ b/wiki/guide/security-rbac.md
@@ -63,7 +63,7 @@ CoSky supports two authentication methods:
 
 ### Login Lockout Mechanism
 
-`UserService.login()` implements progressive account lockout to prevent brute-force attacks. All lock-state transitions run inside the atomic Lua script `user_state.lua` (operations: `login-attempt`, `login-success`, `lock`, `remove`), so concurrent sign-ins can never corrupt the counter.
+`UserService.login()` implements progressive account lockout to prevent brute-force attacks. Each lock-state mutation (`login-attempt`, `login-success`, `lock`, `remove`) executes as a single atomic `user_state.lua` script invocation, so individual counter updates cannot be corrupted by concurrent sign-ins. Note that one full login performs two separate script invocations (attempt, then success after password verification) and `unlock()` deletes the lock key directly, so the end-to-end login sequence is not one atomic unit.
 
 - **Max failed attempts**: 10 (`MAX_LOGIN_ERROR_TIMES`)
 - **Lock tracking**: A Redis key (`cosky-{system}:login_lock:{username}`) is incremented on each login attempt and deleted on successful login. While the count is within the limit, the script refreshes the key's TTL to 15 minutes (`LOGIN_LOCK_EXPIRE`) on every attempt, so a freeze effectively lifts 15 minutes after the last counted attempt.
@@ -251,7 +251,7 @@ Source: [AuditLogService.kt:28-99](https://github.com/Ahoo-Wang/CoSky/blob/main/
 - **User index**: A Redis Hash (`cosky-{system}:user_idx`) mapping usernames to SHA-256 password hashes.
 - **Role bindings**: A Redis Set (`cosky-{system}:user_role_bind:{username}`) storing role names assigned to each user.
 - **Password hashing**: Uses Guava's `Hashing.sha256()` with UTF-8 encoding.
-- **Login lockout**: See [Login Lockout Mechanism](#login-lockout-mechanism) above. All lock-state transitions are executed atomically by the `user_state.lua` script.
+- **Login lockout**: See [Login Lockout Mechanism](#login-lockout-mechanism) above. Each lock-state transition is executed atomically by the `user_state.lua` script.
 - **User listing**: `query()` returns each user with role bindings and a `locked` attribute (`true` when manually locked or over the failed-attempt limit).
 - **Removal guard**: The root user (`cosky`) can be neither removed nor locked.
 - **Root initialization**: `initRoot(enforce)` creates the `cosky` super user with a random password when absent; `enforce = true` removes the existing root first, forcing re-initialization.

--- a/wiki/guide/security-rbac.md
+++ b/wiki/guide/security-rbac.md
@@ -4,7 +4,7 @@ title: Security & RBAC
 
 # Security & RBAC
 
-CoSky implements a comprehensive three-layer security model -- **Authentication**, **Authorization**, and **Audit** -- built on the [CoSec](https://github.com/Ahoo-Wang/CoSec) security framework. User credentials are stored in Redis with SHA-256 hashing. Authorization combines a policy engine (CoSec policy JSON) with namespace-scoped RBAC. All operations are audited and persisted to a Redis List for querying.
+CoSky implements a comprehensive three-layer security model -- **Authentication**, **Authorization**, and **Audit** -- built on the [CoSec](https://github.com/Ahoo-Wang/CoSec) security framework. User credentials are stored in Redis with SHA-256 hashing. Authorization combines a policy engine (CoSec policy JSON) with namespace-scoped RBAC. Operations are audited (write operations by default, configurable) and persisted to a Redis List for querying.
 
 ## At a Glance
 
@@ -52,7 +52,7 @@ flowchart LR
 CoSky supports two authentication methods:
 
 1. **UserPasswordAuthentication** -- validates username/password against SHA-256 hashed credentials stored in Redis. On success, the `UserService.login()` method returns a `SimplePrincipal` with the user's role bindings.
-2. **RefreshTokenAuthentication** -- accepts an access/refresh token pair and validates the refresh token via CoSec's `TokenVerifier`. Returns a refreshed token pair on success.
+2. **RefreshTokenAuthentication** -- accepts an access/refresh token pair and validates the refresh token via CoSec's `TokenVerifier`. After verification it calls `UserService.ensureUnlocked()`, so a locked account can no longer refresh its tokens. Returns a refreshed token pair on success.
 
 ### AuthenticateController Endpoints
 
@@ -63,16 +63,17 @@ CoSky supports two authentication methods:
 
 ### Login Lockout Mechanism
 
-`UserService.login()` implements progressive account lockout to prevent brute-force attacks:
+`UserService.login()` implements progressive account lockout to prevent brute-force attacks. All lock-state transitions run inside the atomic Lua script `user_state.lua` (operations: `login-attempt`, `login-success`, `lock`, `remove`), so concurrent sign-ins can never corrupt the counter.
 
 - **Max failed attempts**: 10 (`MAX_LOGIN_ERROR_TIMES`)
-- **Base lockout duration**: 15 minutes (`LOGIN_LOCK_EXPIRE`)
-- **Maximum lockout**: 3 days (`MAX_LOGIN_LOCK_EXPIRE`)
-- **Exponential backoff**: `lockoutDuration = baseLockout * max(tryCount / maxErrorTimes, 1)`, capped at the maximum.
-- **Lock tracking**: A Redis key (`system:login_lock:{username}`) is incremented on each failed attempt and deleted on successful login.
-- **Unlock**: Admins can unlock a user via `DELETE /v1/users/{username}/unlock`.
+- **Lock tracking**: A Redis key (`cosky-{system}:login_lock:{username}`) is incremented on each login attempt and deleted on successful login. While the count is within the limit, the script refreshes the key's TTL to 15 minutes (`LOGIN_LOCK_EXPIRE`) on every attempt, so a freeze effectively lifts 15 minutes after the last counted attempt.
+- **Freeze message**: Once the count exceeds 10, sign-in is rejected until the key expires. The error message reports a freeze duration computed with progressive backoff: `lockoutDuration = baseLockout * max(tryCount / maxErrorTimes, 1)`, capped at 3 days (`MAX_LOGIN_LOCK_EXPIRE`).
+- **Manual lock**: Admins can lock a user immediately via `PUT /v1/users/{username}/lock`. The script writes a `manual` marker (no TTL) to the lock key, so the account stays locked until explicitly unlocked. The root user (`cosky`) cannot be locked.
+- **Refresh tokens rejected**: Locked users (manual marker or over the failed-attempt limit) are also rejected when refreshing tokens -- see [RefreshTokenAuthentication](#authentication).
+- **Unlock**: Admins can unlock a user via `DELETE /v1/users/{username}/unlock`, which deletes the lock key.
+- **Visibility**: `GET /v1/users` returns a `locked` attribute per user, `true` when the account is manually locked or over the failed-attempt limit.
 
-Source: [UserService.kt:135-177](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L135)
+Sources: [UserService.kt:138-180](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L138), [user_state.lua](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/resources/user_state.lua)
 
 ### Login Flow
 
@@ -90,19 +91,20 @@ sequenceDiagram
     AuthenticateController->>TokenCompositeAuth: authenticateAsToken(UserPasswordCredentials)
     TokenCompositeAuth->>UserPasswordAuth: authenticate(credentials)
     UserPasswordAuth->>UserService: login(username, pwd)
-    UserService->>Redis: INCR system:login_lock:{username}
-    Redis-->>UserService: tryCount
-    alt tryCount > 10
+    UserService->>Redis: EVAL user_state.lua (login-attempt)<br>INCR cosky-{system}:login_lock:{username}
+    Redis-->>UserService: tryCount (-1 if manually locked)
+    alt manually locked (tryCount = -1)
+        UserService-->>UserPasswordAuth: SecurityException (locked by administrator)
+    else tryCount > 10
         UserService-->>UserPasswordAuth: SecurityException (account frozen)
     else within limit
-        UserService->>Redis: GET from system:user_idx (hashed pwd)
+        UserService->>Redis: HGET cosky-{system}:user_idx (hashed pwd)
         Redis-->>UserService: storedHash
         alt SHA-256(pwd) != storedHash
-            UserService->>Redis: EXPIRE lock key (backoff duration)
             UserService-->>UserPasswordAuth: SecurityException (incorrect password)
         else password matches
-            UserService->>Redis: DEL system:login_lock:{username}
-            UserService->>Redis: SMEMBERS system:user_role_bind:{username}
+            UserService->>Redis: EVAL user_state.lua (login-success)<br>DEL login lock key
+            UserService->>Redis: SMEMBERS cosky-{system}:user_role_bind:{username}
             Redis-->>UserService: roleSet
             UserService-->>UserPasswordAuth: SimplePrincipal(id, roles)
         end
@@ -112,7 +114,7 @@ sequenceDiagram
     AuthenticateController-->>Client: 200 CompositeToken
 ```
 
-<!-- Sources: cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt:37, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/UserPasswordAuthentication.kt:11, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt:135 -->
+<!-- Sources: cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt:37, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/UserPasswordAuthentication.kt:11, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt:139, cosky-rest-api/src/main/resources/user_state.lua:31 -->
 
 ## Authorization
 
@@ -148,7 +150,7 @@ flowchart TD
 
 ### CoSkyPolicy and InitialPolicyLoader
 
-`CoSkyPolicy` loads the security policy from CoSky's own config service. The policy is stored as a config item in the `system` namespace. It subscribes to config change events and refreshes the policy cache automatically when updated.
+`CoSkyPolicy` loads the security policy from CoSky's own config service. The policy is stored as a config item in the `cosky-{system}` namespace. It subscribes to config change events and refreshes the policy cache automatically when updated.
 
 If no policy exists in the config service, `InitialPolicyLoader` loads the bundled `cosky-policy.json` from the classpath as a fallback.
 
@@ -211,7 +213,7 @@ classDiagram
 
 ### Super User and Admin Role
 
-- **Super user**: The `cosky` user (root) bypasses all authorization. It is initialized by `SecurityCommand` on application startup when `cosky.security.enforce-init-super-user` is `true`. A random 10-character password is generated and printed to stdout.
+- **Super user**: The `cosky` user (root) bypasses all authorization. `SecurityCommand` calls `UserService.initRoot()` on every application startup; the root user is created with a random 10-character password (printed to stdout) whenever it is absent. Setting `cosky.security.enforce-init-super-user` to `true` additionally deletes the existing root user first, forcing a password reset on every restart.
 - **Admin role**: The `admin` role is a system-reserved role granted full access by the policy engine's `admin` statement. It is automatically included in the role list.
 
 Sources: [UserService.kt:38-52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L38), [Role.kt:31-34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/rbac/Role.kt#L31), [SecurityCommand.kt:25](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/SecurityCommand.kt#L25)
@@ -224,7 +226,7 @@ Sources: [UserService.kt:38-52](https://github.com/Ahoo-Wang/CoSky/blob/main/cos
 
 - **operator** -- the username (from security context, or extracted from the login path)
 - **ip** -- remote address
-- **path** -- request URI
+- **resource** -- request URI
 - **action** -- HTTP method name
 - **status** -- HTTP response status code
 - **msg** -- error message (if any)
@@ -236,9 +238,9 @@ Source: [AuditLogHandlerInterceptor.kt:31-76](https://github.com/Ahoo-Wang/CoSky
 
 ### AuditLogService
 
-`AuditLogService` persists audit log entries as JSON strings in a Redis List (`system:audit:log`). New entries are pushed to the head (`leftPush`). Queries support offset/limit pagination via `range`.
+`AuditLogService` persists audit log entries as JSON strings in a Redis List (`cosky-{system}:audit:log`). New entries are pushed to the head (`leftPush`). Queries support offset/limit pagination via `range`, and the log can be exported as CSV via `GET /v1/audit-log/export`.
 
-Source: [AuditLogService.kt:27-51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogService.kt#L27)
+Source: [AuditLogService.kt:28-99](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogService.kt#L28)
 
 ## User Management
 
@@ -246,17 +248,19 @@ Source: [AuditLogService.kt:27-51](https://github.com/Ahoo-Wang/CoSky/blob/main/
 
 `UserService` manages users entirely in Redis:
 
-- **User index**: A Redis Hash (`system:user_idx`) mapping usernames to SHA-256 password hashes.
-- **Role bindings**: A Redis Set (`system:user_role_bind:{username}`) storing role names assigned to each user.
+- **User index**: A Redis Hash (`cosky-{system}:user_idx`) mapping usernames to SHA-256 password hashes.
+- **Role bindings**: A Redis Set (`cosky-{system}:user_role_bind:{username}`) storing role names assigned to each user.
 - **Password hashing**: Uses Guava's `Hashing.sha256()` with UTF-8 encoding.
-- **Login lockout**: See [Login Lockout Mechanism](#login-lockout-mechanism) above.
-- **Root initialization**: `initRoot(enforce)` creates or resets the `cosky` super user with a random password.
+- **Login lockout**: See [Login Lockout Mechanism](#login-lockout-mechanism) above. All lock-state transitions are executed atomically by the `user_state.lua` script.
+- **User listing**: `query()` returns each user with role bindings and a `locked` attribute (`true` when manually locked or over the failed-attempt limit).
+- **Removal guard**: The root user (`cosky`) can be neither removed nor locked.
+- **Root initialization**: `initRoot(enforce)` creates the `cosky` super user with a random password when absent; `enforce = true` removes the existing root first, forcing re-initialization.
 
-Source: [UserService.kt:36-212](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L36)
+Source: [UserService.kt:36-288](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L36)
 
 ### SecurityCommand
 
-`SecurityCommand` is a `CommandLineRunner` that runs on application startup. It calls `UserService.initRoot()` to initialize the super user. This happens automatically if `cosky.security.enforce-init-super-user` is set to `true`.
+`SecurityCommand` is a `CommandLineRunner` that runs on application startup. It unconditionally calls `UserService.initRoot()`, passing through the `cosky.security.enforce-init-super-user` flag (default `false`). The root user is created whenever it does not exist; the flag only controls whether an existing root is deleted and re-initialized.
 
 Source: [SecurityCommand.kt:25-34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/SecurityCommand.kt#L25)
 
@@ -264,12 +268,13 @@ Source: [SecurityCommand.kt:25-34](https://github.com/Ahoo-Wang/CoSky/blob/main/
 
 | Method | Path | Description | Source |
 |--------|------|-------------|--------|
-| GET | `/v1/users` | List all users with role bindings | [UserController.kt:42](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L42) |
-| POST | `/v1/users/{username}` | Create a new user | [UserController.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L52) |
-| DELETE | `/v1/users/{username}` | Remove a user | [UserController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L62) |
-| PATCH | `/v1/users/{username}/password` | Change password | [UserController.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L47) |
-| PATCH | `/v1/users/{username}/role` | Bind roles to a user | [UserController.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L57) |
-| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | [UserController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L67) |
+| GET | `/v1/users` | List all users with role bindings and lock state | [UserController.kt:44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L44) |
+| POST | `/v1/users/{username}` | Create a new user | [UserController.kt:54](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L54) |
+| DELETE | `/v1/users/{username}` | Remove a user | [UserController.kt:64](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L64) |
+| PATCH | `/v1/users/{username}/password` | Change password | [UserController.kt:49](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L49) |
+| PATCH | `/v1/users/{username}/role` | Bind roles to a user | [UserController.kt:59](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L59) |
+| PUT | `/v1/users/{username}/lock` | Manually lock a user (root cannot be locked) | [UserController.kt:69](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L69) |
+| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | [UserController.kt:74](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L74) |
 
 ## Default Security Policy
 

--- a/wiki/guide/service-registry.md
+++ b/wiki/guide/service-registry.md
@@ -72,8 +72,8 @@ class RedisServiceRegistry(
 
 Key design points:
 - Ephemeral instances are tracked in a `ConcurrentHashMap<NamespacedInstanceId, ServiceInstance>` for heartbeat renewal ([RedisServiceRegistry.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L40)).
-- The `register` method adds to the ephemeral map before executing the Lua script ([RedisServiceRegistry.kt:98](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L98)).
-- If a renew fails (instance key missing), it automatically re-registers the instance ([RedisServiceRegistry.kt:178](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L178)).
+- The `register` method adds to the ephemeral map only after the Lua script succeeds -- inside `doOnNext`, and only when the script returned `true` ([RedisServiceRegistry.kt:97](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L97)).
+- If a renew fails (instance key missing), it automatically re-registers the instance ([RedisServiceRegistry.kt:184](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L184)).
 
 ### DiscoveryRedisScripts
 
@@ -121,7 +121,6 @@ sequenceDiagram
     participant Sub as PubSub Subscribers
 
     App->>SR: register(namespace, serviceInstance)
-    SR->>EMap: addEphemeralInstance(namespace, instance)
     SR->>SR: build ARGV (ttl, serviceId, instanceId, schema, host, port, weight, metadata)
     SR->>Redis: EVAL registry_register.lua KEYS=[namespace] ARGV=[...]
     Redis->>Redis: SADD svc_itc_idx:{serviceId} {instanceId}
@@ -130,10 +129,13 @@ sequenceDiagram
     Redis->>Sub: PUBLISH svc_itc:{instanceId} "register"
     Redis->>Redis: EXPIRE svc_itc:{instanceId} {ttl}
     Redis-->>SR: Boolean (success)
+    alt registered == true
+        SR->>EMap: addEphemeralInstance(namespace, instance)
+    end
     SR-->>App: Mono<Boolean>
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_register.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:43, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:26 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_register.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:92, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:26 -->
 
 ### Renew / Heartbeat Flow
 
@@ -164,7 +166,7 @@ sequenceDiagram
     end
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_renew.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewInstanceService.kt:70, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:160 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_renew.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewInstanceService.kt:70, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:163 -->
 
 ### Deregister Flow
 
@@ -191,7 +193,7 @@ sequenceDiagram
     SR-->>App: Mono<Boolean>
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_deregister.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:188, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:29 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_deregister.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:191, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:29 -->
 
 ## Redis Key Structure
 
@@ -202,9 +204,11 @@ The registry uses a structured key pattern for organizing service and instance d
 | `{namespace}:svc_idx` | SET | Set of all service IDs in the namespace | `production:svc_idx` |
 | `{namespace}:svc_stat` | HASH | Service ID to instance count statistics | `production:svc_stat` |
 | `{namespace}:svc_itc_idx:{serviceId}` | SET | Set of instance IDs for a given service | `production:svc_itc_idx:order-service` |
-| `{namespace}:svc_itc:{instanceId}` | HASH | Instance data (fields: instanceId, serviceId, schema, host, port, weight, ephemeral, ttl_at, metadata) | `production:svc_itc:order-service@http#10.0.1.5#8080` |
+| `{namespace}:svc_itc:{instanceId}` | HASH | Instance data (fields: instanceId, serviceId, schema, host, port, weight, ephemeral, metadata) | `production:svc_itc:order-service@http#10.0.1.5#8080` |
 | `{namespace}:topology_idx` | HASH | Topology index: consumer name to timestamp | `production:topology_idx` |
 | `{namespace}:topology:{consumer}` | HASH | Topology deps: producer name to timestamp | `production:topology:gateway-service` |
+
+Note: `ttl_at` is **not** stored in the instance hash. It is computed at read time as `now + ttl` by the discovery scripts ([discovery_get_instances.lua:33](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/discovery_get_instances.lua#L33), [discovery_get_instance.lua:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/discovery_get_instance.lua#L30)). The renew script may additionally write the system field `__last_renew_pub_ttl_at` into the hash for publish throttling ([registry_renew.lua:9](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/registry_renew.lua#L9)).
 
 The instance ID format is `{serviceId}@{schema}#{host}#{port}` (e.g., `order-service@http#10.0.1.5#8080`), as defined in [`Instance.asInstanceId`](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/Instance.kt#L57).
 

--- a/wiki/guide/spring-cloud-config.md
+++ b/wiki/guide/spring-cloud-config.md
@@ -209,7 +209,7 @@ With the above configuration, CoSky will:
 ## Related Pages
 
 - [Spring Cloud Discovery Starter](/guide/spring-cloud-discovery) -- service registration and discovery backed by Redis
-- [Configuration Center](/guide/config) -- CoSky's config management APIs and Redis storage model
+- [Configuration Center](/guide/config-service) -- CoSky's config management APIs and Redis storage model
 
 ## References
 

--- a/wiki/guide/spring-cloud-discovery.md
+++ b/wiki/guide/spring-cloud-discovery.md
@@ -94,7 +94,7 @@ CoSky provides two discovery client implementations that adapt the CoSky `Servic
 
 ### Blocking: CoSkyDiscoveryClient
 
-The [CoSkyDiscoveryClient](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt) implements Spring's `DiscoveryClient`. It delegates to the reactive `ServiceDiscovery` and blocks with the configured timeout ([CoSkyDiscoveryClient.kt:33](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt#L33)). Each `ServiceInstance` from CoSky is wrapped in a `CoSkyServiceInstance` adapter.
+The [CoSkyDiscoveryClient](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt) implements Spring's `DiscoveryClient`. It delegates to the reactive `ServiceDiscovery` and blocks with the configured timeout ([CoSkyDiscoveryClient.kt:36](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt#L36)). Each `ServiceInstance` from CoSky is wrapped in a `CoSkyServiceInstance` adapter.
 
 ### Reactive: CoSkyReactiveDiscoveryClient
 
@@ -135,7 +135,7 @@ sequenceDiagram
 
 ### CoSkyServiceRegistry
 
-The [CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt) implements Spring's `ServiceRegistry<CoSkyRegistration>` interface. On `register()`, it delegates to the CoSky `ServiceRegistry` to persist the instance in Redis, then starts the heartbeat `RenewInstanceService` ([CoSkyServiceRegistry.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L30)). On `deregister()`, it removes the instance and stops the heartbeat. The `close()` method also stops the renewal service ([CoSkyServiceRegistry.kt:45](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L45)).
+The [CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt) implements Spring's `ServiceRegistry<CoSkyRegistration>` interface. On `register()`, it delegates to the CoSky `ServiceRegistry` to persist the instance in Redis, then starts the heartbeat `RenewInstanceService` ([CoSkyServiceRegistry.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L30)). On `deregister()`, it only removes the instance via the CoSky `ServiceRegistry` -- the heartbeat keeps running ([CoSkyServiceRegistry.kt:38](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L38)). The renewal service is stopped by `close()` ([CoSkyServiceRegistry.kt:45](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L45)).
 
 ### CoSkyRegistration
 
@@ -147,7 +147,7 @@ The [CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-sp
 
 ### Auto-Registration for Non-Web Apps
 
-[CoSkyAutoServiceRegistrationOfNoneWeb](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt) handles non-web applications (e.g. gRPC services, CLI tools). It listens for `ApplicationStartedEvent` and, if the application context is not a `WebServerApplicationContext`, registers the service using the **process ID (PID) as the port** ([CoSkyAutoServiceRegistrationOfNoneWeb.kt:51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt#L51)). This provides a meaningful identifier even when there is no HTTP port.
+[CoSkyAutoServiceRegistrationOfNoneWeb](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt) handles non-web applications (e.g. gRPC services, CLI tools). It listens for `ApplicationStartedEvent` and, if the application context is not a `WebServerApplicationContext`, registers the service using the **process ID (PID) as the port** ([CoSkyAutoServiceRegistrationOfNoneWeb.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt#L52)). This provides a meaningful identifier even when there is no HTTP port.
 
 ### Service Registration Flow
 
@@ -197,13 +197,13 @@ sequenceDiagram
 The discovery starter uses `ConsistencyRedisServiceDiscovery` as the primary `ServiceDiscovery` bean ([CoSkyDiscoveryAutoConfiguration.kt:81](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L81)). This decorator wraps `RedisServiceDiscovery` with local consistency guarantees by subscribing to:
 
 - **ServiceEventListenerContainer** -- listens for Redis Pub/Sub events when services are added or removed ([CoSkyDiscoveryAutoConfiguration.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L62)).
-- **InstanceEventListenerContainer** -- listens for Redis Pub/Sub events when individual instances change (register, deregister, metadata update) ([CoSkyDiscoveryAutoConfiguration.kt:69](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L69)).
+- **InstanceEventListenerContainer** -- listens for Redis Pub/Sub events when individual instances change (register, deregister, metadata update) ([CoSkyDiscoveryAutoConfiguration.kt:71](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L71)).
 
 This event-driven approach ensures that local service caches are invalidated and refreshed promptly without relying on polling.
 
 ## Load Balancer Integration
 
-CoSky provides a custom `BinaryWeightRandomLoadBalancer` ([CoSkyDiscoveryAutoConfiguration.kt:106](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L106)) that respects per-instance weights. It uses a binary-search algorithm over a cumulative weight array for O(log n) instance selection. The load balancer extends `AbstractLoadBalancer` and rebuilds its chooser whenever `InstanceEventListenerContainer` reports a change in the instance list.
+CoSky provides a custom `BinaryWeightRandomLoadBalancer` ([CoSkyDiscoveryAutoConfiguration.kt:109](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L109)) that respects per-instance weights. It uses a binary-search algorithm over a cumulative weight array for O(log n) instance selection. The load balancer extends `AbstractLoadBalancer` and rebuilds its chooser whenever `InstanceEventListenerContainer` reports a change in the instance list.
 
 ## Class Diagram
 
@@ -347,8 +347,8 @@ With this configuration, the `order-service` will:
 ## Related Pages
 
 - [Spring Cloud Config Starter](/guide/spring-cloud-config) -- Redis-backed configuration management with live refresh
-- [Service Discovery](/guide/discovery) -- CoSky's core service discovery API and Redis data model
-- [Service Registry](/guide/registry) -- CoSky's service registration and heartbeat mechanism
+- [Service Discovery](/guide/service-discovery) -- CoSky's core service discovery API and Redis data model
+- [Service Registry](/guide/service-registry) -- CoSky's service registration and heartbeat mechanism
 
 ## References
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -31,7 +31,7 @@ features:
     details: 100K+ QPS for standard operations, 70M+ QPS with consistency caching layer. Powered by Redis Lua scripts and in-process caching.
   - title: Spring Cloud Native
     icon: 🌿
-    details: Drop-in Spring Cloud integration via starters. Supports both reactive (WebClient) and blocking (RestClient) programming models.
+    details: Drop-in Spring Cloud integration via starters for both configuration and service discovery.
   - title: Security & RBAC
     icon: 🔐
     details: JWT authentication, namespace-scoped RBAC, audit logging, and policy-based authorization powered by CoSec.

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -8,7 +8,7 @@
 | Feature | Description | Source |
 |---------|-------------|--------|
 | **Service Discovery** | Register, discover, and manage service instances with automatic renewal via client heartbeat. Supports weighted load balancing and service topology. | [ServiceRegistry.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceRegistry.kt#L24), [ServiceDiscovery.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceDiscovery.kt#L24) |
-| **Configuration Management** | Dynamic configuration with version history (last 10 versions), rollback support, and file import/export. Changes propagate instantly via Redis PubSub. | [ConfigService.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigService.kt#L24), [ConfigRollback.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigRollback.kt#L24) |
+| **Configuration Management** | Dynamic configuration with version history and rollback support, plus file import/export. Changes propagate instantly via Redis PubSub. | [ConfigService.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigService.kt#L24), [ConfigRollback.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigRollback.kt#L24) |
 | **Consistency Caching** | Local process cache kept in sync via Redis PubSub, achieving 250x-800x performance improvement over direct Redis reads. | [RedisConsistencyConfigService](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt), [ConsistencyRedisServiceDiscovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/ConsistencyRedisServiceDiscovery.kt) |
 | **Spring Cloud Integration** | Drop-in starters for both config and discovery. Auto-configures via Spring Boot `@AutoConfiguration`. | [CoSkyConfigAutoConfiguration.kt:43](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L43), [CoSkyDiscoveryAutoConfiguration.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L47) |
 | **Weighted Load Balancing** | Binary weight random load balancer integrated with service discovery for efficient instance selection. | [CoSkyDiscoveryAutoConfiguration.kt:105](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L105) |
@@ -23,8 +23,8 @@
 graph TB
     subgraph Applications["Applications"]
         style Applications fill:#161b22,stroke:#30363d,color:#e6edf3
-        A["Spring Boot App 1"] --> |uses| SC_C["spring-cloud-starter-cosky-config"]
-        A --> |uses| SC_D["spring-cloud-starter-cosky-discovery"]
+        A["Spring Boot App 1"] --> |uses| SC_C["cosky-spring-cloud-starter-config"]
+        A --> |uses| SC_D["cosky-spring-cloud-starter-discovery"]
         B["Spring Boot App 2"] --> |uses| SC_C
         B --> |uses| SC_D
     end
@@ -75,8 +75,8 @@ graph LR
         style Modules fill:#161b22,stroke:#30363d,color:#e6edf3
         CORE["cosky-core"] --> CONFIG["cosky-config"]
         CORE --> DISCOVERY["cosky-discovery"]
-        CONFIG --> SCC["spring-cloud-starter-cosky-config"]
-        DISCOVERY --> SCD["spring-cloud-starter-cosky-discovery"]
+        CONFIG --> SCC["cosky-spring-cloud-starter-config"]
+        DISCOVERY --> SCD["cosky-spring-cloud-starter-discovery"]
         SCC --> REST["cosky-rest-api"]
         SCD --> REST
         SC_CORE["cosky-spring-cloud-core"] --> SCC
@@ -260,9 +260,10 @@ graph LR
 val coskyVersion = "5.7.2"
 
 dependencies {
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 }
 ```
@@ -277,6 +278,13 @@ dependencies {
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
+            <artifactId>cosky-bom</artifactId>
+            <version>${cosky.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.ahoo.cosky</groupId>
             <artifactId>cosky-dependencies</artifactId>
             <version>${cosky.version}</version>
             <type>pom</type>
@@ -287,11 +295,11 @@ dependencies {
 <dependencies>
     <dependency>
         <groupId>me.ahoo.cosky</groupId>
-        <artifactId>spring-cloud-starter-cosky-config</artifactId>
+        <artifactId>cosky-spring-cloud-starter-config</artifactId>
     </dependency>
     <dependency>
         <groupId>me.ahoo.cosky</groupId>
-        <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
+        <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
     </dependency>
     <dependency>
         <groupId>org.springframework.cloud</groupId>
@@ -304,27 +312,25 @@ Current version defined in [gradle.properties:14](https://github.com/Ahoo-Wang/C
 
 ### Step 2: Configure Bootstrap
 
-Create `src/main/resources/bootstrap.yaml`:
+Create `src/main/resources/bootstrap.yaml`. Shown below is the configuration used by the bundled example provider:
 
 ```yaml
+server:
+  port: 8099
 spring:
   application:
-    name: ${service.name:my-service}
-  data:
-    redis:
-      url: redis://localhost:6379
+    name: ${service.name:example-provider}
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-{default}}
+      namespace: ${cosky.namespace:dev}
       config:
         config-id: ${spring.application.name}.yaml
-    service-registry:
-      auto-registration:
-        enabled: ${cosky.auto-registry:true}
 logging:
   file:
     name: logs/${spring.application.name}.log
 ```
+
+The example relies on Spring Boot's default Redis connection (`localhost:6379`); set `spring.data.redis.url` explicitly if your Redis instance runs elsewhere. Service auto-registration is enabled by default (`spring.cloud.service-registry.auto-registration.enabled`).
 
 | Property | Default | Description |
 |----------|---------|-------------|
@@ -332,7 +338,7 @@ logging:
 | `spring.cloud.cosky.namespace` | `cosky-{default}` | Namespace for service/config isolation ([CoSkyProperties.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt#L30)) |
 | `spring.cloud.cosky.config.config-id` | `${spring.application.name}.yaml` | Config file ID to load ([CoSkyConfigAutoConfiguration.kt:48](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L48)) |
 | `spring.cloud.service-registry.auto-registration.enabled` | `true` | Auto-register service on startup |
-| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension for config lookup ([CoSkyConfigProperties.kt:27](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L27)) |
+| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension for config lookup ([CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28)) |
 
 Source: [examples/cosky-service-provider/src/main/resources/bootstrap.yaml](https://github.com/Ahoo-Wang/CoSky/blob/main/examples/cosky-service-provider/src/main/resources/bootstrap.yaml)
 
@@ -547,9 +553,10 @@ Add CoSky starters to your Spring Cloud application. These are published to Mave
 val coskyVersion = "5.7.2"
 
 dependencies {
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
     implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 }
 ```
@@ -571,6 +578,13 @@ dependencies {
         <dependencies>
             <dependency>
                 <groupId>me.ahoo.cosky</groupId>
+                <artifactId>cosky-bom</artifactId>
+                <version>${cosky.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>me.ahoo.cosky</groupId>
                 <artifactId>cosky-dependencies</artifactId>
                 <version>${cosky.version}</version>
                 <type>pom</type>
@@ -582,11 +596,11 @@ dependencies {
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-config</artifactId>
+            <artifactId>cosky-spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
+            <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -596,15 +610,16 @@ dependencies {
 </project>
 ```
 
-Source: [gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14), [README.md:46-87](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L46-L87)
+Source: [gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14), [README.md:46-108](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L46-L108)
 
 ### Available Artifacts
 
 | Artifact | Purpose | Module |
 |----------|---------|--------|
-| `spring-cloud-starter-cosky-config` | Spring Cloud config loading and real-time refresh | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
-| `spring-cloud-starter-cosky-discovery` | Spring Cloud service registration and discovery | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
-| `cosky-bom` | Bill of Materials for dependency version management | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
+| `cosky-spring-cloud-starter-config` | Spring Cloud config loading and real-time refresh | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
+| `cosky-spring-cloud-starter-discovery` | Spring Cloud service registration and discovery | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
+| `cosky-bom` | Bill of Materials — manages CoSky module versions | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
+| `cosky-dependencies` | Version catalog — manages Spring Boot / Spring Cloud / CosID / Simba / CoSec versions (required for the versionless `spring-cloud-starter-loadbalancer`) | [cosky-dependencies](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-dependencies) |
 
 ## REST API Server Installation
 
@@ -612,19 +627,24 @@ The REST API server provides a management dashboard, REST endpoints, security (R
 
 ### Option 1: Standalone JAR
 
-Download the latest release and run directly:
+GitHub releases do not publish prebuilt archives, so build the server distribution from source (JDK 17 required):
 
 ```bash
-# Download cosky-server
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# (Optional) Build the dashboard first so the web UI is bundled into the distribution
+cd dashboard && pnpm install && pnpm build && cd ..
 
-# Extract
-tar -xvf cosky-server.tar
-cd cosky-server
+# Build the distribution archive
+./gradlew :cosky-rest-api:distTar
+
+# Extract (the archive name includes the version)
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
+cd cosky-rest-api-5.7.2
 
 # Run with Redis connection
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
+
+The distribution contains `bin/` start scripts, `lib/` dependencies, `config/` configuration files, and `ui/` with the dashboard static resources (served via `spring.web.resources.static-locations: file:./ui/`).
 
 On first startup, CoSky initializes the super user and prints the generated password to the console:
 
@@ -634,7 +654,7 @@ On first startup, CoSky initializes the super user and prints the generated pass
 
 To reinitialize the password, set `enforce-init-super-user: true` in your configuration.
 
-Source: [README.md:119-127](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L119-L127)
+Source: [cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44), [cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13), [README.md:267](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L267)
 
 ### Option 2: Docker
 
@@ -671,7 +691,7 @@ services:
       - redis
 ```
 
-Source: [README.md:132-137](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L132-L137)
+Source: [README.md:159-163](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L159-L163)
 
 ### Option 3: Kubernetes
 
@@ -695,20 +715,18 @@ spec:
     metadata:
       labels:
         app: cosky
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
-        - name: cosky
-          image: ahoowang/cosky:latest
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-          env:
+        - env:
             - name: SPRING_DATA_REDIS_HOST
               value: redis-uri:6379
             - name: SPRING_DATA_REDIS_PASSWORD
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           startupProbe:
             httpGet:
               port: http
@@ -721,21 +739,29 @@ spec:
             httpGet:
               port: http
               path: /actuator/health/liveness
+          name: cosky
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
           resources:
-            requests:
-              cpu: 250m
-              memory: 1024Mi
             limits:
               cpu: "1"
               memory: 1280Mi
+            requests:
+              cpu: 250m
+              memory: 1024Mi
           volumeMounts:
-            - name: volume-localtime
-              mountPath: /etc/localtime
+            - mountPath: /etc/localtime
+              name: volume-localtime
       volumes:
-        - name: volume-localtime
-          hostPath:
+        - hostPath:
             path: /etc/localtime
+            type: ""
+          name: volume-localtime
 ```
+
+> **Note:** The example above uses the current release `5.7.2`. The in-repo manifest ([k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)) still pins the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` from Docker Hub.
 
 Source: [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -759,11 +785,13 @@ spec:
     metadata:
       labels:
         app: cosky
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
-        - name: cosky
-          image: ahoowang/cosky:latest
-          env:
+        - env:
+            - name: LANG
+              value: C.utf8
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:
                 secretKeyRef:
@@ -780,6 +808,41 @@ spec:
               value: "true"
             - name: SPRING_DATA_REDIS_LETTUCE_CLUSTER_REFRESH_PERIOD
               value: 30s
+            - name: TZ
+              value: Asia/Shanghai
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
+          startupProbe:
+            httpGet:
+              port: http
+              path: /actuator/health
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /actuator/health/readiness
+          livenessProbe:
+            httpGet:
+              port: http
+              path: /actuator/health/liveness
+          name: cosky
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1280Mi
+            requests:
+              cpu: 250m
+              memory: 1024Mi
+          volumeMounts:
+            - mountPath: /etc/localtime
+              name: volume-localtime
+      volumes:
+        - hostPath:
+            path: /etc/localtime
+            type: ""
+          name: volume-localtime
 ```
 
 Source: [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml)
@@ -856,8 +919,8 @@ Key configuration properties for CoSky:
 | `spring.cloud.cosky.namespace` | `cosky-{default}` | Isolation namespace for services and configs | [CoSkyProperties.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt#L30) |
 | `spring.cloud.cosky.config.enabled` | `true` | Enable config loading from Redis | [CoSkyConfigProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L26) |
 | `spring.cloud.cosky.config.config-id` | `${spring.application.name}.yaml` | Config file ID to load | [CoSkyConfigAutoConfiguration.kt:48](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L48) |
-| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension | [CoSkyConfigProperties.kt:27](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L27) |
-| `spring.cloud.cosky.config.timeout` | `2s` | Timeout for config loading | [CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28) |
+| `spring.cloud.cosky.config.file-extension` | `yaml` | Default file extension | [CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28) |
+| `spring.cloud.cosky.config.timeout` | `2s` | Timeout for config loading | [CoSkyConfigProperties.kt:29](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L29) |
 | `spring.cloud.cosky.discovery.enabled` | `true` | Enable service discovery | [CoSkyDiscoveryProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt#L26) |
 | `spring.cloud.cosky.discovery.timeout` | `2s` | Timeout for discovery operations | [CoSkyDiscoveryProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt#L28) |
 | `spring.cloud.service-registry.auto-registration.enabled` | `true` | Auto-register service on startup | [bootstrap.yaml:9](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/bootstrap.yaml#L9) |
@@ -872,7 +935,7 @@ When using the discovery starter, service instances have configurable TTL and he
 |----------|---------|-------------|--------|
 | Instance TTL | `60s` | How long an instance lives before being considered expired | [RegistryProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RegistryProperties.kt#L26) |
 | Renew period | `10s` | How often the instance sends a heartbeat to renew its TTL | [RenewProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L28) |
-| Renew initial delay | `1s` | Delay before the first heartbeat after registration | [RenewProperties.kt:25](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L25) |
+| Renew initial delay | `1s` | Delay before the first heartbeat after registration | [RenewProperties.kt:23](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L23) |
 
 ```mermaid
 %%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#2d333b','primaryBorderColor':'#6d5dfc','primaryTextColor':'#e6edf3','lineColor':'#8b949e','secondaryColor':'#161b22','tertiaryColor':'#161b22'}}}%%
@@ -939,7 +1002,7 @@ The dashboard provides:
 - Service topology visualization
 - Import/export functionality (including Nacos migration)
 
-Source: [README.md:206-219](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L206-L219)
+Source: [README.md:238-246](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L238-L246)
 
 ## References
 
@@ -1108,7 +1171,7 @@ sequenceDiagram
 | Lettuce | latest | Redis client driver (async, reactive) | [cosky-core/build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-core/build.gradle.kts) |
 | Project Reactor | latest | Reactive programming model (Flux, Mono) | [cosky-core/build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-core/build.gradle.kts) |
 | Lua (Redis scripting) | N/A | Atomic multi-step operations | [DiscoveryRedisScripts.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt) |
-| Gradle (Kotlin DSL) | 8.x | Build system | [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) |
+| Gradle (Kotlin DSL) | 9.x | Build system | [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) |
 
 ## Design Principles
 
@@ -1881,18 +1944,24 @@ spring:
       url: redis://localhost:6379
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-production}
+      namespace: ${cosky.namespace:cosky-{default}}
       config:
         config-id: ${spring.application.name}.yaml
+    service-registry:
+      auto-registration:
+        enabled: ${cosky.auto-registry:true}
+logging:
+  file:
+    name: logs/${spring.application.name}.log
 ```
 
 | Config Property | Description | Example |
 |---|---|---|
 | `spring.data.redis.url` | Redis connection URL | `redis://localhost:6379` |
-| `spring.cloud.cosky.namespace` | Namespace for config isolation | `cosky-production` |
+| `spring.cloud.cosky.namespace` | Namespace for config isolation | `cosky-{default}` |
 | `spring.cloud.cosky.config.config-id` | The configId to load (typically `{app}.yaml`) | `order-service.yaml` |
 
-Source: [README.md:89](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L89)
+Source: [README.md:111](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L111)
 
 ## Rollback Mechanism
 
@@ -2139,7 +2208,7 @@ The key detail is that the cache stores a `Mono<Config>` that has been `.cache()
 
 ## Cache Invalidation Flow
 
-When any process modifies a configuration, the Lua script publishes a change event on the Redis PubSub channel. Every instance listening on that channel receives the invalidation and refreshes its cache.
+When any process modifies a configuration, the Lua script publishes a change event on the Redis PubSub channel. Every instance listening on that channel receives the invalidation and lazily refreshes its cache.
 
 ```mermaid
 sequenceDiagram
@@ -2160,16 +2229,14 @@ sequenceDiagram
     PS-->>Listener: Message received
     Listener->>Listener: Parse ConfigChangedEvent
     Listener-->>RCS: onConfigChanged(event)
-    RCS->>Cache: remove old entry
-    RCS->>RDS: getConfig(namespace, configId)
-    RDS->>Redis: HGETALL
-    Redis-->>RDS: new config data
-    RDS-->>RCS: Config
-    RCS->>Cache: put new cached Mono
-    Note over Cache: Next read returns<br>fresh data
+    RCS->>Cache: Overwrite entry with a new cold<br>Mono cached with 1-minute TTL
+    Note over RCS,Cache: No Redis call happens here -- the fetch is deferred<br>until the next getConfig() subscriber arrives
+    Note over Cache: Next read re-executes the fetch<br>and returns fresh data
 ```
 
 <!-- Sources: RedisConsistencyConfigService.kt:68, RedisConfigEventListenerContainer.kt:18, config_set.lua:1 -->
+
+The invalidation path is a single overwrite: `onConfigChanged` replaces the map entry with `delegate.getConfig(...).cache(CONFIG_CACHE_TTL)` -- a cold `Mono` that is never subscribed at invalidation time (hence the `@Suppress("ReactiveStreamsUnusedPublisher")` in the source). The event type (`SET`, `REMOVE`, `ROLLBACK`) is not inspected; all three follow the identical overwrite path, and a removed config simply yields a cached *empty* `Mono`.
 
 ## Event Listener Container
 
@@ -2215,28 +2282,23 @@ The local cache for each configuration entry goes through a well-defined set of 
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Empty: Initial state
+    [*] --> CachedNoTTL: First getConfig() call<br>entry = getConfig().cache()
 
-    Empty --> Loading: First getConfig() call
-    Loading --> Valid: Redis returns Config data
-    Loading --> Empty: Redis returns null / error
+    CachedNoTTL --> CachedNoTTL: Subsequent getConfig() (cache hit,<br>never expires on its own)
+    CachedNoTTL --> CachedTTL: Any PubSub event (set / remove /<br>rollback) overwrites the entry
 
-    Valid --> Valid: Subsequent getConfig() (cache hit)
-    Valid --> Invalidated: PubSub event received
+    CachedTTL --> CachedTTL: getConfig() within TTL (cache hit)
+    CachedTTL --> Refetching: Cache TTL reached (1 minute)
+    Refetching --> CachedTTL: Next getConfig() re-executes the fetch<br>and caches for another minute
+    CachedTTL --> CachedTTL: Next PubSub event (overwrite)
 
-    Invalidated --> Loading: Re-fetch from Redis
-    Invalidated --> Removed: Event type = REMOVE
-
-    Removed --> Loading: New getConfig() call
-    Removed --> [*]: Config no longer exists
-
-    Valid --> TTLExpired: Cache TTL reached (1 minute)
-    TTLExpired --> Loading: Re-fetch from Redis
+    CachedNoTTL --> [*]: Listener terminated<br>(entry removed from map)
+    CachedTTL --> [*]: Listener terminated<br>(entry removed from map)
 ```
 
-<!-- Sources: RedisConsistencyConfigService.kt:40, RedisConsistencyConfigService.kt:46 -->
+<!-- Sources: RedisConsistencyConfigService.kt:40, RedisConsistencyConfigService.kt:46, RedisConsistencyConfigService.kt:57, RedisConsistencyConfigService.kt:68 -->
 
-The `CONFIG_CACHE_TTL` is set to `Duration.ofMinutes(1)`. When a cache entry is refreshed due to a PubSub invalidation event, the new `Mono` is created with `.cache(CONFIG_CACHE_TTL)`, ensuring that even without further invalidation events, stale data is eventually evicted.
+The `CONFIG_CACHE_TTL` is set to `Duration.ofMinutes(1)`, but it applies **only to entries written by the PubSub refresh path** (`onConfigChanged` uses `.cache(CONFIG_CACHE_TTL)`). The initial cache entry, created on the first `getConfig()` call, uses plain `.cache()` with **no TTL** and never expires on its own. If the PubSub listener terminates, its `doFinally` hook removes the entry from the map, so the next `getConfig()` re-creates the entry and re-subscribes.
 
 Source: [RedisConsistencyConfigService.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt#L40)
 
@@ -2284,7 +2346,9 @@ Each cached configuration entry occupies memory in the JVM heap for the `Concurr
 
 ### PubSub Reliability
 
-Redis PubSub is a fire-and-forget protocol -- if an instance is temporarily disconnected (network blip, GC pause), it will miss invalidation messages. CoSky mitigates this through the `CONFIG_CACHE_TTL` of 1 minute: even if an invalidation event is missed, the cache entry will expire and be re-fetched from Redis within 60 seconds.
+Redis PubSub is a fire-and-forget protocol -- if an instance is temporarily disconnected (network blip, GC pause), it will miss invalidation messages. The `CONFIG_CACHE_TTL` of 1 minute bounds this staleness **only for entries that have already been refreshed by a previous invalidation event**: those entries are re-fetched from Redis at most 60 seconds after their last refresh. The initial cache entry, however, is created with plain `.cache()` (no TTL) and never expires on its own -- if the very first invalidation event for a config is missed, that entry keeps serving stale data until a later event arrives, the listener terminates (which evicts the entry), or the process restarts.
+
+Source: [RedisConsistencyConfigService.kt:64-76](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt#L64)
 
 ### Delegation Pattern
 
@@ -2381,8 +2445,8 @@ class RedisServiceRegistry(
 
 Key design points:
 - Ephemeral instances are tracked in a `ConcurrentHashMap<NamespacedInstanceId, ServiceInstance>` for heartbeat renewal ([RedisServiceRegistry.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L40)).
-- The `register` method adds to the ephemeral map before executing the Lua script ([RedisServiceRegistry.kt:98](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L98)).
-- If a renew fails (instance key missing), it automatically re-registers the instance ([RedisServiceRegistry.kt:178](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L178)).
+- The `register` method adds to the ephemeral map only after the Lua script succeeds -- inside `doOnNext`, and only when the script returned `true` ([RedisServiceRegistry.kt:97](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L97)).
+- If a renew fails (instance key missing), it automatically re-registers the instance ([RedisServiceRegistry.kt:184](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L184)).
 
 ### DiscoveryRedisScripts
 
@@ -2430,7 +2494,6 @@ sequenceDiagram
     participant Sub as PubSub Subscribers
 
     App->>SR: register(namespace, serviceInstance)
-    SR->>EMap: addEphemeralInstance(namespace, instance)
     SR->>SR: build ARGV (ttl, serviceId, instanceId, schema, host, port, weight, metadata)
     SR->>Redis: EVAL registry_register.lua KEYS=[namespace] ARGV=[...]
     Redis->>Redis: SADD svc_itc_idx:{serviceId} {instanceId}
@@ -2439,10 +2502,13 @@ sequenceDiagram
     Redis->>Sub: PUBLISH svc_itc:{instanceId} "register"
     Redis->>Redis: EXPIRE svc_itc:{instanceId} {ttl}
     Redis-->>SR: Boolean (success)
+    alt registered == true
+        SR->>EMap: addEphemeralInstance(namespace, instance)
+    end
     SR-->>App: Mono<Boolean>
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_register.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:43, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:26 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_register.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:92, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:26 -->
 
 ### Renew / Heartbeat Flow
 
@@ -2473,7 +2539,7 @@ sequenceDiagram
     end
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_renew.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewInstanceService.kt:70, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:160 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_renew.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewInstanceService.kt:70, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:163 -->
 
 ### Deregister Flow
 
@@ -2500,7 +2566,7 @@ sequenceDiagram
     SR-->>App: Mono<Boolean>
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_deregister.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:188, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:29 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_deregister.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:191, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:29 -->
 
 ## Redis Key Structure
 
@@ -2511,9 +2577,11 @@ The registry uses a structured key pattern for organizing service and instance d
 | `{namespace}:svc_idx` | SET | Set of all service IDs in the namespace | `production:svc_idx` |
 | `{namespace}:svc_stat` | HASH | Service ID to instance count statistics | `production:svc_stat` |
 | `{namespace}:svc_itc_idx:{serviceId}` | SET | Set of instance IDs for a given service | `production:svc_itc_idx:order-service` |
-| `{namespace}:svc_itc:{instanceId}` | HASH | Instance data (fields: instanceId, serviceId, schema, host, port, weight, ephemeral, ttl_at, metadata) | `production:svc_itc:order-service@http#10.0.1.5#8080` |
+| `{namespace}:svc_itc:{instanceId}` | HASH | Instance data (fields: instanceId, serviceId, schema, host, port, weight, ephemeral, metadata) | `production:svc_itc:order-service@http#10.0.1.5#8080` |
 | `{namespace}:topology_idx` | HASH | Topology index: consumer name to timestamp | `production:topology_idx` |
 | `{namespace}:topology:{consumer}` | HASH | Topology deps: producer name to timestamp | `production:topology:gateway-service` |
+
+Note: `ttl_at` is **not** stored in the instance hash. It is computed at read time as `now + ttl` by the discovery scripts ([discovery_get_instances.lua:33](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/discovery_get_instances.lua#L33), [discovery_get_instance.lua:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/discovery_get_instance.lua#L30)). The renew script may additionally write the system field `__last_renew_pub_ttl_at` into the hash for publish throttling ([registry_renew.lua:9](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/registry_renew.lua#L9)).
 
 The instance ID format is `{serviceId}@{schema}#{host}#{port}` (e.g., `order-service@http#10.0.1.5#8080`), as defined in [`Instance.asInstanceId`](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/Instance.kt#L57).
 
@@ -3107,7 +3175,7 @@ val instance = Instance.asInstance(
     metadata = mapOf("version" to "v2")
 )
 
-serviceRegistry.register(instance = instance).block()
+serviceRegistry.register(serviceInstance = instance).block()
 ```
 
 The weight is stored in the Redis hash under the `weight` field and decoded by `ServiceInstanceCodec` ([ServiceInstanceCodec.kt:32](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt#L32)).
@@ -3578,7 +3646,7 @@ With the above configuration, CoSky will:
 ## Related Pages
 
 - [Spring Cloud Discovery Starter](/guide/spring-cloud-discovery) -- service registration and discovery backed by Redis
-- [Configuration Center](/guide/config) -- CoSky's config management APIs and Redis storage model
+- [Configuration Center](/guide/config-service) -- CoSky's config management APIs and Redis storage model
 
 ## References
 
@@ -3683,7 +3751,7 @@ CoSky provides two discovery client implementations that adapt the CoSky `Servic
 
 ### Blocking: CoSkyDiscoveryClient
 
-The [CoSkyDiscoveryClient](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt) implements Spring's `DiscoveryClient`. It delegates to the reactive `ServiceDiscovery` and blocks with the configured timeout ([CoSkyDiscoveryClient.kt:33](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt#L33)). Each `ServiceInstance` from CoSky is wrapped in a `CoSkyServiceInstance` adapter.
+The [CoSkyDiscoveryClient](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt) implements Spring's `DiscoveryClient`. It delegates to the reactive `ServiceDiscovery` and blocks with the configured timeout ([CoSkyDiscoveryClient.kt:36](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt#L36)). Each `ServiceInstance` from CoSky is wrapped in a `CoSkyServiceInstance` adapter.
 
 ### Reactive: CoSkyReactiveDiscoveryClient
 
@@ -3724,7 +3792,7 @@ sequenceDiagram
 
 ### CoSkyServiceRegistry
 
-The [CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt) implements Spring's `ServiceRegistry<CoSkyRegistration>` interface. On `register()`, it delegates to the CoSky `ServiceRegistry` to persist the instance in Redis, then starts the heartbeat `RenewInstanceService` ([CoSkyServiceRegistry.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L30)). On `deregister()`, it removes the instance and stops the heartbeat. The `close()` method also stops the renewal service ([CoSkyServiceRegistry.kt:45](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L45)).
+The [CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt) implements Spring's `ServiceRegistry<CoSkyRegistration>` interface. On `register()`, it delegates to the CoSky `ServiceRegistry` to persist the instance in Redis, then starts the heartbeat `RenewInstanceService` ([CoSkyServiceRegistry.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L30)). On `deregister()`, it only removes the instance via the CoSky `ServiceRegistry` -- the heartbeat keeps running ([CoSkyServiceRegistry.kt:38](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L38)). The renewal service is stopped by `close()` ([CoSkyServiceRegistry.kt:45](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L45)).
 
 ### CoSkyRegistration
 
@@ -3736,7 +3804,7 @@ The [CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-sp
 
 ### Auto-Registration for Non-Web Apps
 
-[CoSkyAutoServiceRegistrationOfNoneWeb](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt) handles non-web applications (e.g. gRPC services, CLI tools). It listens for `ApplicationStartedEvent` and, if the application context is not a `WebServerApplicationContext`, registers the service using the **process ID (PID) as the port** ([CoSkyAutoServiceRegistrationOfNoneWeb.kt:51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt#L51)). This provides a meaningful identifier even when there is no HTTP port.
+[CoSkyAutoServiceRegistrationOfNoneWeb](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt) handles non-web applications (e.g. gRPC services, CLI tools). It listens for `ApplicationStartedEvent` and, if the application context is not a `WebServerApplicationContext`, registers the service using the **process ID (PID) as the port** ([CoSkyAutoServiceRegistrationOfNoneWeb.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt#L52)). This provides a meaningful identifier even when there is no HTTP port.
 
 ### Service Registration Flow
 
@@ -3786,13 +3854,13 @@ sequenceDiagram
 The discovery starter uses `ConsistencyRedisServiceDiscovery` as the primary `ServiceDiscovery` bean ([CoSkyDiscoveryAutoConfiguration.kt:81](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L81)). This decorator wraps `RedisServiceDiscovery` with local consistency guarantees by subscribing to:
 
 - **ServiceEventListenerContainer** -- listens for Redis Pub/Sub events when services are added or removed ([CoSkyDiscoveryAutoConfiguration.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L62)).
-- **InstanceEventListenerContainer** -- listens for Redis Pub/Sub events when individual instances change (register, deregister, metadata update) ([CoSkyDiscoveryAutoConfiguration.kt:69](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L69)).
+- **InstanceEventListenerContainer** -- listens for Redis Pub/Sub events when individual instances change (register, deregister, metadata update) ([CoSkyDiscoveryAutoConfiguration.kt:71](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L71)).
 
 This event-driven approach ensures that local service caches are invalidated and refreshed promptly without relying on polling.
 
 ## Load Balancer Integration
 
-CoSky provides a custom `BinaryWeightRandomLoadBalancer` ([CoSkyDiscoveryAutoConfiguration.kt:106](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L106)) that respects per-instance weights. It uses a binary-search algorithm over a cumulative weight array for O(log n) instance selection. The load balancer extends `AbstractLoadBalancer` and rebuilds its chooser whenever `InstanceEventListenerContainer` reports a change in the instance list.
+CoSky provides a custom `BinaryWeightRandomLoadBalancer` ([CoSkyDiscoveryAutoConfiguration.kt:109](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L109)) that respects per-instance weights. It uses a binary-search algorithm over a cumulative weight array for O(log n) instance selection. The load balancer extends `AbstractLoadBalancer` and rebuilds its chooser whenever `InstanceEventListenerContainer` reports a change in the instance list.
 
 ## Class Diagram
 
@@ -3936,8 +4004,8 @@ With this configuration, the `order-service` will:
 ## Related Pages
 
 - [Spring Cloud Config Starter](/guide/spring-cloud-config) -- Redis-backed configuration management with live refresh
-- [Service Discovery](/guide/discovery) -- CoSky's core service discovery API and Redis data model
-- [Service Registry](/guide/registry) -- CoSky's service registration and heartbeat mechanism
+- [Service Discovery](/guide/service-discovery) -- CoSky's core service discovery API and Redis data model
+- [Service Registry](/guide/service-registry) -- CoSky's service registration and heartbeat mechanism
 
 ## References
 
@@ -4045,12 +4113,13 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 
 | Method | Path | Description | Controller Method | Source |
 |--------|------|-------------|-------------------|--------|
-| GET | `/v1/users` | List all users with roles | `query` | [UserController.kt:42](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L42) |
-| POST | `/v1/users/{username}` | Add a new user | `addUser` | [UserController.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L52) |
-| DELETE | `/v1/users/{username}` | Remove a user | `removeUser` | [UserController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L62) |
-| PATCH | `/v1/users/{username}/password` | Change password | `changePwd` | [UserController.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L47) |
-| PATCH | `/v1/users/{username}/role` | Bind roles to user | `bindRole` | [UserController.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L57) |
-| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | `unlock` | [UserController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L67) |
+| GET | `/v1/users` | List all users with roles | `query` | [UserController.kt:44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L44) |
+| POST | `/v1/users/{username}` | Add a new user | `addUser` | [UserController.kt:54](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L54) |
+| DELETE | `/v1/users/{username}` | Remove a user | `removeUser` | [UserController.kt:64](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L64) |
+| PATCH | `/v1/users/{username}/password` | Change password | `changePwd` | [UserController.kt:49](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L49) |
+| PATCH | `/v1/users/{username}/role` | Bind roles to user | `bindRole` | [UserController.kt:59](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L59) |
+| PUT | `/v1/users/{username}/lock` | Lock a user (manual lock; root user cannot be locked) | `lock` | [UserController.kt:68](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L68) |
+| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | `unlock` | [UserController.kt:74](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L74) |
 
 ### Role Endpoints
 
@@ -4065,7 +4134,8 @@ All endpoints share the `/v1` prefix. The following tables group them by domain.
 
 | Method | Path | Description | Controller Method | Source |
 |--------|------|-------------|-------------------|--------|
-| GET | `/v1/audit-log` | Query audit logs | `queryLog` | [AuditLogController.kt:32](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L32) |
+| GET | `/v1/audit-log` | Query audit logs | `queryLog` | [AuditLogController.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L40) |
+| GET | `/v1/audit-log/export` | Export audit log as CSV | `exportLog` | [AuditLogController.kt:51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L51) |
 
 ## Sequence Diagrams
 
@@ -4192,12 +4262,12 @@ cosky:
     enabled: true                    # Enable/disable security
     audit-log:
       action: write                  # Audit log filter: "write", "read", or "rw"
-    enforce-init-super-user: false   # Force re-initialize super user on startup
+    enforce-init-super-user: ${cosky.super.init:false}   # Force re-initialize super user on startup
 
 cosec:
   jwt:
     algorithm: hmac256               # JWT signing algorithm
-    secret: ${cosky.security.key}    # JWT secret key
+    secret: ${cosky.security.key:FyN0Igd80Gas3stTavArGKOYnS9uLWGA$}    # JWT secret key
     token-validity:
       access: 15m                    # Access token TTL
       refresh: 3H                    # Refresh token TTL
@@ -4238,7 +4308,7 @@ Source: [cosky-rest-api/src/main/resources/application.yaml](https://github.com/
 <doc title="Security & RBAC" path="guide/security-rbac.md">
 # Security & RBAC
 
-CoSky implements a comprehensive three-layer security model -- **Authentication**, **Authorization**, and **Audit** -- built on the [CoSec](https://github.com/Ahoo-Wang/CoSec) security framework. User credentials are stored in Redis with SHA-256 hashing. Authorization combines a policy engine (CoSec policy JSON) with namespace-scoped RBAC. All operations are audited and persisted to a Redis List for querying.
+CoSky implements a comprehensive three-layer security model -- **Authentication**, **Authorization**, and **Audit** -- built on the [CoSec](https://github.com/Ahoo-Wang/CoSec) security framework. User credentials are stored in Redis with SHA-256 hashing. Authorization combines a policy engine (CoSec policy JSON) with namespace-scoped RBAC. Operations are audited (write operations by default, configurable) and persisted to a Redis List for querying.
 
 ## At a Glance
 
@@ -4286,7 +4356,7 @@ flowchart LR
 CoSky supports two authentication methods:
 
 1. **UserPasswordAuthentication** -- validates username/password against SHA-256 hashed credentials stored in Redis. On success, the `UserService.login()` method returns a `SimplePrincipal` with the user's role bindings.
-2. **RefreshTokenAuthentication** -- accepts an access/refresh token pair and validates the refresh token via CoSec's `TokenVerifier`. Returns a refreshed token pair on success.
+2. **RefreshTokenAuthentication** -- accepts an access/refresh token pair and validates the refresh token via CoSec's `TokenVerifier`. After verification it calls `UserService.ensureUnlocked()`, so a locked account can no longer refresh its tokens. Returns a refreshed token pair on success.
 
 ### AuthenticateController Endpoints
 
@@ -4297,16 +4367,17 @@ CoSky supports two authentication methods:
 
 ### Login Lockout Mechanism
 
-`UserService.login()` implements progressive account lockout to prevent brute-force attacks:
+`UserService.login()` implements progressive account lockout to prevent brute-force attacks. Each lock-state mutation (`login-attempt`, `login-success`, `lock`, `remove`) executes as a single atomic `user_state.lua` script invocation, so individual counter updates cannot be corrupted by concurrent sign-ins. Note that one full login performs two separate script invocations (attempt, then success after password verification) and `unlock()` deletes the lock key directly, so the end-to-end login sequence is not one atomic unit.
 
 - **Max failed attempts**: 10 (`MAX_LOGIN_ERROR_TIMES`)
-- **Base lockout duration**: 15 minutes (`LOGIN_LOCK_EXPIRE`)
-- **Maximum lockout**: 3 days (`MAX_LOGIN_LOCK_EXPIRE`)
-- **Exponential backoff**: `lockoutDuration = baseLockout * max(tryCount / maxErrorTimes, 1)`, capped at the maximum.
-- **Lock tracking**: A Redis key (`system:login_lock:{username}`) is incremented on each failed attempt and deleted on successful login.
-- **Unlock**: Admins can unlock a user via `DELETE /v1/users/{username}/unlock`.
+- **Lock tracking**: A Redis key (`cosky-{system}:login_lock:{username}`) is incremented on each login attempt and deleted on successful login. While the count is within the limit, the script refreshes the key's TTL to 15 minutes (`LOGIN_LOCK_EXPIRE`) on every attempt, so a freeze effectively lifts 15 minutes after the last counted attempt.
+- **Freeze message**: Once the count exceeds 10, sign-in is rejected until the key expires. The error message reports a freeze duration computed with progressive backoff: `lockoutDuration = baseLockout * max(tryCount / maxErrorTimes, 1)`, capped at 3 days (`MAX_LOGIN_LOCK_EXPIRE`).
+- **Manual lock**: Admins can lock a user immediately via `PUT /v1/users/{username}/lock`. The script writes a `manual` marker (no TTL) to the lock key, so the account stays locked until explicitly unlocked. The root user (`cosky`) cannot be locked.
+- **Refresh tokens rejected**: Locked users (manual marker or over the failed-attempt limit) are also rejected when refreshing tokens -- see [RefreshTokenAuthentication](#authentication).
+- **Unlock**: Admins can unlock a user via `DELETE /v1/users/{username}/unlock`, which deletes the lock key.
+- **Visibility**: `GET /v1/users` returns a `locked` attribute per user, `true` when the account is manually locked or over the failed-attempt limit.
 
-Source: [UserService.kt:135-177](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L135)
+Sources: [UserService.kt:138-180](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L138), [user_state.lua](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/resources/user_state.lua)
 
 ### Login Flow
 
@@ -4324,19 +4395,20 @@ sequenceDiagram
     AuthenticateController->>TokenCompositeAuth: authenticateAsToken(UserPasswordCredentials)
     TokenCompositeAuth->>UserPasswordAuth: authenticate(credentials)
     UserPasswordAuth->>UserService: login(username, pwd)
-    UserService->>Redis: INCR system:login_lock:{username}
-    Redis-->>UserService: tryCount
-    alt tryCount > 10
+    UserService->>Redis: EVAL user_state.lua (login-attempt)<br>INCR cosky-{system}:login_lock:{username}
+    Redis-->>UserService: tryCount (-1 if manually locked)
+    alt manually locked (tryCount = -1)
+        UserService-->>UserPasswordAuth: SecurityException (locked by administrator)
+    else tryCount > 10
         UserService-->>UserPasswordAuth: SecurityException (account frozen)
     else within limit
-        UserService->>Redis: GET from system:user_idx (hashed pwd)
+        UserService->>Redis: HGET cosky-{system}:user_idx (hashed pwd)
         Redis-->>UserService: storedHash
         alt SHA-256(pwd) != storedHash
-            UserService->>Redis: EXPIRE lock key (backoff duration)
             UserService-->>UserPasswordAuth: SecurityException (incorrect password)
         else password matches
-            UserService->>Redis: DEL system:login_lock:{username}
-            UserService->>Redis: SMEMBERS system:user_role_bind:{username}
+            UserService->>Redis: EVAL user_state.lua (login-success)<br>DEL login lock key
+            UserService->>Redis: SMEMBERS cosky-{system}:user_role_bind:{username}
             Redis-->>UserService: roleSet
             UserService-->>UserPasswordAuth: SimplePrincipal(id, roles)
         end
@@ -4346,7 +4418,7 @@ sequenceDiagram
     AuthenticateController-->>Client: 200 CompositeToken
 ```
 
-<!-- Sources: cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt:37, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/UserPasswordAuthentication.kt:11, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt:135 -->
+<!-- Sources: cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt:37, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/UserPasswordAuthentication.kt:11, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt:139, cosky-rest-api/src/main/resources/user_state.lua:31 -->
 
 ## Authorization
 
@@ -4382,7 +4454,7 @@ flowchart TD
 
 ### CoSkyPolicy and InitialPolicyLoader
 
-`CoSkyPolicy` loads the security policy from CoSky's own config service. The policy is stored as a config item in the `system` namespace. It subscribes to config change events and refreshes the policy cache automatically when updated.
+`CoSkyPolicy` loads the security policy from CoSky's own config service. The policy is stored as a config item in the `cosky-{system}` namespace. It subscribes to config change events and refreshes the policy cache automatically when updated.
 
 If no policy exists in the config service, `InitialPolicyLoader` loads the bundled `cosky-policy.json` from the classpath as a fallback.
 
@@ -4445,7 +4517,7 @@ classDiagram
 
 ### Super User and Admin Role
 
-- **Super user**: The `cosky` user (root) bypasses all authorization. It is initialized by `SecurityCommand` on application startup when `cosky.security.enforce-init-super-user` is `true`. A random 10-character password is generated and printed to stdout.
+- **Super user**: The `cosky` user (root) bypasses all authorization. `SecurityCommand` calls `UserService.initRoot()` on every application startup; the root user is created with a random 10-character password (printed to stdout) whenever it is absent. Setting `cosky.security.enforce-init-super-user` to `true` additionally deletes the existing root user first, forcing a password reset on every restart.
 - **Admin role**: The `admin` role is a system-reserved role granted full access by the policy engine's `admin` statement. It is automatically included in the role list.
 
 Sources: [UserService.kt:38-52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L38), [Role.kt:31-34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/rbac/Role.kt#L31), [SecurityCommand.kt:25](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/SecurityCommand.kt#L25)
@@ -4458,7 +4530,7 @@ Sources: [UserService.kt:38-52](https://github.com/Ahoo-Wang/CoSky/blob/main/cos
 
 - **operator** -- the username (from security context, or extracted from the login path)
 - **ip** -- remote address
-- **path** -- request URI
+- **resource** -- request URI
 - **action** -- HTTP method name
 - **status** -- HTTP response status code
 - **msg** -- error message (if any)
@@ -4470,9 +4542,9 @@ Source: [AuditLogHandlerInterceptor.kt:31-76](https://github.com/Ahoo-Wang/CoSky
 
 ### AuditLogService
 
-`AuditLogService` persists audit log entries as JSON strings in a Redis List (`system:audit:log`). New entries are pushed to the head (`leftPush`). Queries support offset/limit pagination via `range`.
+`AuditLogService` persists audit log entries as JSON strings in a Redis List (`cosky-{system}:audit:log`). New entries are pushed to the head (`leftPush`). Queries support offset/limit pagination via `range`, and the log can be exported as CSV via `GET /v1/audit-log/export`.
 
-Source: [AuditLogService.kt:27-51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogService.kt#L27)
+Source: [AuditLogService.kt:28-99](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogService.kt#L28)
 
 ## User Management
 
@@ -4480,17 +4552,19 @@ Source: [AuditLogService.kt:27-51](https://github.com/Ahoo-Wang/CoSky/blob/main/
 
 `UserService` manages users entirely in Redis:
 
-- **User index**: A Redis Hash (`system:user_idx`) mapping usernames to SHA-256 password hashes.
-- **Role bindings**: A Redis Set (`system:user_role_bind:{username}`) storing role names assigned to each user.
+- **User index**: A Redis Hash (`cosky-{system}:user_idx`) mapping usernames to SHA-256 password hashes.
+- **Role bindings**: A Redis Set (`cosky-{system}:user_role_bind:{username}`) storing role names assigned to each user.
 - **Password hashing**: Uses Guava's `Hashing.sha256()` with UTF-8 encoding.
-- **Login lockout**: See [Login Lockout Mechanism](#login-lockout-mechanism) above.
-- **Root initialization**: `initRoot(enforce)` creates or resets the `cosky` super user with a random password.
+- **Login lockout**: See [Login Lockout Mechanism](#login-lockout-mechanism) above. Each lock-state transition is executed atomically by the `user_state.lua` script.
+- **User listing**: `query()` returns each user with role bindings and a `locked` attribute (`true` when manually locked or over the failed-attempt limit).
+- **Removal guard**: The root user (`cosky`) can be neither removed nor locked.
+- **Root initialization**: `initRoot(enforce)` creates the `cosky` super user with a random password when absent; `enforce = true` removes the existing root first, forcing re-initialization.
 
-Source: [UserService.kt:36-212](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L36)
+Source: [UserService.kt:36-288](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L36)
 
 ### SecurityCommand
 
-`SecurityCommand` is a `CommandLineRunner` that runs on application startup. It calls `UserService.initRoot()` to initialize the super user. This happens automatically if `cosky.security.enforce-init-super-user` is set to `true`.
+`SecurityCommand` is a `CommandLineRunner` that runs on application startup. It unconditionally calls `UserService.initRoot()`, passing through the `cosky.security.enforce-init-super-user` flag (default `false`). The root user is created whenever it does not exist; the flag only controls whether an existing root is deleted and re-initialized.
 
 Source: [SecurityCommand.kt:25-34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/SecurityCommand.kt#L25)
 
@@ -4498,12 +4572,13 @@ Source: [SecurityCommand.kt:25-34](https://github.com/Ahoo-Wang/CoSky/blob/main/
 
 | Method | Path | Description | Source |
 |--------|------|-------------|--------|
-| GET | `/v1/users` | List all users with role bindings | [UserController.kt:42](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L42) |
-| POST | `/v1/users/{username}` | Create a new user | [UserController.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L52) |
-| DELETE | `/v1/users/{username}` | Remove a user | [UserController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L62) |
-| PATCH | `/v1/users/{username}/password` | Change password | [UserController.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L47) |
-| PATCH | `/v1/users/{username}/role` | Bind roles to a user | [UserController.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L57) |
-| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | [UserController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L67) |
+| GET | `/v1/users` | List all users with role bindings and lock state | [UserController.kt:44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L44) |
+| POST | `/v1/users/{username}` | Create a new user | [UserController.kt:54](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L54) |
+| DELETE | `/v1/users/{username}` | Remove a user | [UserController.kt:64](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L64) |
+| PATCH | `/v1/users/{username}/password` | Change password | [UserController.kt:49](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L49) |
+| PATCH | `/v1/users/{username}/role` | Bind roles to a user | [UserController.kt:59](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L59) |
+| PUT | `/v1/users/{username}/lock` | Manually lock a user (root cannot be locked) | [UserController.kt:69](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L69) |
+| DELETE | `/v1/users/{username}/unlock` | Unlock a locked-out user | [UserController.kt:74](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L74) |
 
 ## Default Security Policy
 
@@ -4563,13 +4638,13 @@ Source: [cosky-rest-api/src/main/resources/cosky-policy.json](https://github.com
 <doc title="Dashboard" path="guide/dashboard.md">
 # Dashboard
 
-The CoSky Dashboard is a modern single-page application built with React 19, TypeScript, and Ant Design 6. It provides a visual management interface for all CoSky capabilities: service monitoring, configuration management, service topology visualization, RBAC administration, user management, and audit log review. The dashboard is served directly by the REST API server as static assets and communicates with the backend exclusively through the CoSky REST API.
+The CoSky Dashboard is a modern single-page application built with React 19, TypeScript, Radix UI, and shadcn/ui (styled with Tailwind CSS 4). It provides a visual management interface for all CoSky capabilities: service monitoring, configuration management, service topology visualization, RBAC administration, user management, and audit log review. The dashboard is served directly by the REST API server as static assets and communicates with the backend exclusively through the CoSky REST API.
 
 ## At a Glance
 
 | Aspect | Detail | Key File | Source |
 |--------|--------|----------|--------|
-| Frontend app | React 19 SPA with Ant Design 6 | `dashboard/package.json` | [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json) |
+| Frontend app | React 19 SPA with Radix UI + shadcn/ui | `dashboard/package.json` | [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json) |
 | SPA route serving | Serves `index.html` for all dashboard routes | `DashboardConfiguration.kt` | [cosky-rest-api/.../DashboardConfiguration.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/dashboard/DashboardConfiguration.kt#L30) |
 | API client | Auto-generated from OpenAPI spec | `dashboard/src/generated/` | [dashboard/package.json:12](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json#L12) |
 
@@ -4577,18 +4652,23 @@ The CoSky Dashboard is a modern single-page application built with React 19, Typ
 
 | Technology | Version | Purpose |
 |-----------|---------|---------|
-| React | 19.2.6 | UI framework |
+| React | 19.2.6 | UI framework (with React Compiler) |
 | TypeScript | ~6.0.3 | Type-safe development |
 | Vite | 8.0.16 | Build tool and dev server |
-| Ant Design | 6.3.7 | UI component library |
+| Radix UI | 1.6.7 | Headless UI primitives |
+| shadcn/ui | 4.18.0 | Vendored component pattern (`src/components/ui/`) |
+| Tailwind CSS | 4.3.3 | Utility-first styling |
+| lucide-react | 1.31.0 | Icon set |
+| sonner | 2.0.8 | Toast notifications |
 | React Router DOM | 7.15.1 | Client-side routing |
 | @xyflow/react | 12.10.2 | Service topology visualization |
-| Monaco Editor | 0.55.1 | Configuration text editor |
+| Monaco Editor | 0.55.1 (via @monaco-editor/react 4.7.0) | Configuration text editor |
 | @ahoo-wang/fetcher | 3.16.10 | HTTP client with CoSec auth |
 | @ahoo-wang/fetcher-react | 3.16.10 | React hooks for API calls |
 | @ahoo-wang/fetcher-cosec | 3.16.10 | CoSec token refresh integration |
-| @ahoo-wang/fetcher-viewer | 3.16.10 | Data table and filter components |
+| @ahoo-wang/fetcher-storage | 3.16.10 | Token storage |
 | @ahoo-wang/fetcher-generator | 3.16.10 | OpenAPI code generation |
+| Playwright | 1.62.1 | Unit and end-to-end UI testing |
 
 Source: [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json)
 
@@ -4632,13 +4712,17 @@ The role management page allows administrators to create roles and assign namesp
 
 ![User](/dashboard-user.png)
 
-User management supports creating users, assigning roles, changing passwords, and unlocking locked accounts.
+User management supports creating users, assigning roles, changing passwords, and locking/unlocking accounts. Each row shows a `locked` badge reflecting the account state returned by the API. A manually locked user can no longer sign in or refresh tokens until an administrator unlocks the account; the root user (`cosky`) cannot be locked. See [Security & RBAC](/guide/security-rbac#login-lockout-mechanism) for the lockout semantics.
 
 ### Audit Log
 
 ![Audit Log](/dashboard-audit-log.png)
 
-The audit log page displays a paginated list of all audited operations with operator, IP, path, action, status, and timestamp columns.
+The audit log page displays a paginated list of all audited operations with operator, IP, resource, action, status, and timestamp columns, and can export the audit log as a CSV file (`GET /v1/audit-log/export`).
+
+### Navigation Search
+
+The sidebar includes a keyboard-first navigation search. Press `/` anywhere outside an input field to focus it, filter pages by name or description, move with `ArrowUp`/`ArrowDown`, and jump with `Enter`.
 
 ### Login
 
@@ -4662,10 +4746,10 @@ flowchart TD
     end
 
     subgraph "Redis"
-        UserRedis["User Index<br>system:user_idx"]
+        UserRedis["User Index<br>cosky-{system}:user_idx"]
         ConfigRedis["Configs<br>Namespaced keys"]
         ServiceRedis["Services<br>Namespaced keys"]
-        AuditRedis["Audit Log<br>system:audit:log"]
+        AuditRedis["Audit Log<br>cosky-{system}:audit:log"]
     end
 
     SPA -->|"HTML/JS/CSS"| DashboardConfig
@@ -5036,7 +5120,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           ports:
             - name: http
               containerPort: 8080
@@ -5079,6 +5163,10 @@ spec:
 
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
+::: tip Image tag
+The manifests below use the current release `5.7.2` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). The in-repo manifests ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)) still pin the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` on Docker Hub.
+:::
+
 ## Clustered Redis Deployment
 
 For production environments with Redis Cluster, use the cluster manifest which reads connection details from a Kubernetes Secret:
@@ -5104,7 +5192,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           env:
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:
@@ -5387,32 +5475,37 @@ flowchart LR
 
 The standalone deployment option lets you run CoSky directly on a host machine without Docker or Kubernetes. This approach is ideal for development environments, small-scale deployments, or environments where container runtimes are not available. The standalone distribution packages CoSky as a self-contained application with startup scripts, configuration files, and the built-in dashboard UI.
 
-## Download and Extract
+## Build and Extract
 
-Download the latest release tarball and extract it:
+GitHub releases do not publish a pre-built tarball, so build the standalone distribution from source (JDK 17+ required):
 
 ```bash
-# Download the latest release
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# Build the dashboard first (dashboard/dist is gitignored;
+# without this step the archive has no web UI)
+cd dashboard && pnpm install && pnpm build && cd ..
+
+# Build the distribution tarball
+./gradlew :cosky-rest-api:distTar
 
 # Extract
-tar -xvf cosky-server.tar
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
 
 # Enter the directory
-cd cosky-server
+cd cosky-rest-api-5.7.2
 ```
+
+The distribution bundles the dashboard static files from `dashboard/dist` into `ui/`.
 
 The extracted directory structure contains:
 
 ```
-cosky-server/
+cosky-rest-api-5.7.2/
   bin/
-    cosky              # Startup script (Unix)
+    cosky-rest-api     # Startup script (Unix)
   config/
     application.yaml   # Application configuration
     bootstrap.yaml     # Bootstrap configuration
-  dashboard/
-    dist/              # Dashboard UI static files
+  ui/                  # Dashboard UI static files
   lib/
     *.jar              # Runtime dependencies
 ```
@@ -5422,7 +5515,7 @@ cosky-server/
 Start CoSky with the required Redis connection parameter:
 
 ```bash
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 All Spring Boot properties can be passed as command-line arguments using the `--property=value` format. Alternatively, set them as environment variables or edit the configuration files directly.
@@ -5439,7 +5532,7 @@ flowchart TD
     C -->|"Yes"| E["Kubernetes Deployment"]
     C -->|"No"| F["Docker / Docker Compose"]
     D --> G{"JDK 17+<br>installed?"}
-    G -->|"Yes"| H["Download tarball<br>bin/cosky"]
+    G -->|"Yes"| H["Build tarball<br>bin/cosky-rest-api"]
     G -->|"No"| I["Install JDK 17+"]
     I --> H
     H --> J{"Redis<br>available?"}
@@ -5483,7 +5576,7 @@ spring:
           weight: 8
   web:
     resources:
-      static-locations: file:./dashboard/dist/
+      static-locations: file:./ui/
 cosky:
   security:
     enabled: true
@@ -5582,7 +5675,7 @@ sequenceDiagram
     participant R as Redis
     participant US as cosky (super user)
 
-    OS->>JVM: bin/cosky --server.port=8080
+    OS->>JVM: bin/cosky-rest-api --server.port=8080
     JVM->>SB: start application context
     SB->>SB: load bootstrap.yaml
     SB->>SB: resolve application name: cosky-rest-api
@@ -5645,7 +5738,7 @@ To pass JVM options through the startup script, set the `JAVA_OPTS` environment 
 
 ```bash
 export JAVA_OPTS="-Xms512M -Xmx512M -XX:+UseZGC"
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 ## Service Discovery and Self-Registration
@@ -5689,7 +5782,7 @@ logging:
 To change the log location, override the `logging.file.name` property:
 
 ```bash
-bin/cosky --logging.file.name=/var/log/cosky/cosky.log
+bin/cosky-rest-api --logging.file.name=/var/log/cosky/cosky.log
 ```
 
 ## Related Pages

--- a/wiki/llms.txt
+++ b/wiki/llms.txt
@@ -41,7 +41,7 @@
 
 - [REST API Server](guide/rest-api.md) — HTTP endpoints for all CoSky operations
 - [Security & RBAC](guide/security-rbac.md) — JWT auth, namespace-scoped RBAC, audit logging
-- [Dashboard](guide/dashboard.md) — React 19 + Ant Design 6 web management interface
+- [Dashboard](guide/dashboard.md) — React 19 + Radix UI + shadcn/ui web management interface
 
 ## Deployment
 

--- a/wiki/package.json
+++ b/wiki/package.json
@@ -15,12 +15,6 @@
     "vitepress": "2.0.0-alpha.18",
     "vitepress-mermaid-renderer": "^1.1.27"
   },
-  "pnpm": {
-    "overrides": {
-      "dompurify": "^3.4.11",
-      "js-yaml": "^4.2.0"
-    }
-  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }

--- a/wiki/pnpm-workspace.yaml
+++ b/wiki/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+overrides:
+  dompurify: ^3.4.11
+  js-yaml: ^4.2.0
+allowBuilds:
+  puppeteer: true

--- a/wiki/zh/guide/architecture.md
+++ b/wiki/zh/guide/architecture.md
@@ -156,7 +156,7 @@ sequenceDiagram
 | Lettuce | 最新 | Redis 客户端驱动（异步、响应式） | [cosky-core/build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-core/build.gradle.kts) |
 | Project Reactor | 最新 | 响应式编程模型（Flux、Mono） | [cosky-core/build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-core/build.gradle.kts) |
 | Lua (Redis 脚本) | N/A | 原子多步操作 | [DiscoveryRedisScripts.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt) |
-| Gradle (Kotlin DSL) | 8.x | 构建系统 | [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) |
+| Gradle (Kotlin DSL) | 9.x | 构建系统 | [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) |
 
 ## 设计原则
 

--- a/wiki/zh/guide/config-consistency.md
+++ b/wiki/zh/guide/config-consistency.md
@@ -136,7 +136,7 @@ sequenceDiagram
 
 ## 缓存失效流程
 
-当任何进程修改配置时，Lua 脚本在 Redis PubSub 通道上发布变更事件。监听该通道的每个实例收到失效通知并刷新缓存。
+当任何进程修改配置时，Lua 脚本在 Redis PubSub 通道上发布变更事件。监听该通道的每个实例收到失效通知并惰性刷新缓存。
 
 ```mermaid
 sequenceDiagram
@@ -157,16 +157,14 @@ sequenceDiagram
     PS-->>Listener: 收到消息
     Listener->>Listener: 解析 ConfigChangedEvent
     Listener-->>RCS: onConfigChanged(event)
-    RCS->>Cache: 移除旧条目
-    RCS->>RDS: getConfig(namespace, configId)
-    RDS->>Redis: HGETALL
-    Redis-->>RDS: 新配置数据
-    RDS-->>RCS: Config
-    RCS->>Cache: 存入新的缓存 Mono
-    Note over Cache: 下次读取返回<br>最新数据
+    RCS->>Cache: 用新的冷 Mono 覆盖条目<br>（缓存 TTL 为 1 分钟）
+    Note over RCS,Cache: 此处不会发起 Redis 调用——获取被推迟到<br>下一个 getConfig() 订阅者到来时
+    Note over Cache: 下次读取会重新执行获取<br>并返回最新数据
 ```
 
 <!-- Sources: RedisConsistencyConfigService.kt:68, RedisConfigEventListenerContainer.kt:18, config_set.lua:1 -->
+
+失效路径是一次性覆盖：`onConfigChanged` 用 `delegate.getConfig(...).cache(CONFIG_CACHE_TTL)` 替换映射表中的条目——这是一个冷 `Mono`，在失效时不会被订阅（源码中因此标注了 `@Suppress("ReactiveStreamsUnusedPublisher")`）。事件类型（`SET`、`REMOVE`、`ROLLBACK`）不会被区分处理；三者走完全相同的覆盖路径，被删除的配置只是得到一个缓存的*空* `Mono`。
 
 ## 事件监听器容器
 
@@ -212,28 +210,23 @@ Source: [RedisConfigEventListenerContainer.kt:18](https://github.com/Ahoo-Wang/C
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Empty: 初始状态
+    [*] --> CachedNoTTL: 首次 getConfig() 调用<br>条目 = getConfig().cache()
 
-    Empty --> Loading: 首次 getConfig() 调用
-    Loading --> Valid: Redis 返回 Config 数据
-    Loading --> Empty: Redis 返回 null / 错误
+    CachedNoTTL --> CachedNoTTL: 后续 getConfig()（缓存命中，<br>自身永不过期）
+    CachedNoTTL --> CachedTTL: 任意 PubSub 事件（set / remove /<br>rollback）覆盖该条目
 
-    Valid --> Valid: 后续 getConfig()（缓存命中）
-    Valid --> Invalidated: 收到 PubSub 事件
+    CachedTTL --> CachedTTL: TTL 内的 getConfig()（缓存命中）
+    CachedTTL --> Refetching: 缓存 TTL 到达（1 分钟）
+    Refetching --> CachedTTL: 下次 getConfig() 重新执行获取<br>并再缓存一分钟
+    CachedTTL --> CachedTTL: 下一个 PubSub 事件（覆盖）
 
-    Invalidated --> Loading: 从 Redis 重新获取
-    Invalidated --> Removed: 事件类型 = REMOVE
-
-    Removed --> Loading: 新的 getConfig() 调用
-    Removed --> [*]: 配置不再存在
-
-    Valid --> TTLExpired: 缓存 TTL 到达（1 分钟）
-    TTLExpired --> Loading: 从 Redis 重新获取
+    CachedNoTTL --> [*]: 监听器终止<br>（条目从映射表移除）
+    CachedTTL --> [*]: 监听器终止<br>（条目从映射表移除）
 ```
 
-<!-- Sources: RedisConsistencyConfigService.kt:40, RedisConsistencyConfigService.kt:46 -->
+<!-- Sources: RedisConsistencyConfigService.kt:40, RedisConsistencyConfigService.kt:46, RedisConsistencyConfigService.kt:57, RedisConsistencyConfigService.kt:68 -->
 
-`CONFIG_CACHE_TTL` 设置为 `Duration.ofMinutes(1)`。当缓存条目因 PubSub 失效事件而刷新时，新的 `Mono` 使用 `.cache(CONFIG_CACHE_TTL)` 创建，确保即使没有后续失效事件，过期数据最终也会被驱逐。
+`CONFIG_CACHE_TTL` 设置为 `Duration.ofMinutes(1)`，但它**仅作用于 PubSub 刷新路径写入的条目**（`onConfigChanged` 使用 `.cache(CONFIG_CACHE_TTL)`）。首次 `getConfig()` 调用创建的初始缓存条目使用不带 TTL 的 `.cache()`，**自身永不过期**。如果 PubSub 监听器终止，其 `doFinally` 钩子会将条目从映射表中移除，因此下一次 `getConfig()` 会重新创建条目并重新订阅。
 
 Source: [RedisConsistencyConfigService.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt#L40)
 
@@ -281,7 +274,9 @@ Lua 脚本 PUBLISH -> Redis PubSub 通道 -> 订阅者回调 -> 缓存刷新
 
 ### PubSub 可靠性
 
-Redis PubSub 是一种即发即忘协议——如果实例暂时断开连接（网络抖动、GC 暂停），它将错过失效消息。CoSky 通过 `CONFIG_CACHE_TTL`（1 分钟）来缓解这个问题：即使错过了失效事件，缓存条目也会在 60 秒内过期并从 Redis 重新获取。
+Redis PubSub 是一种即发即忘协议——如果实例暂时断开连接（网络抖动、GC 暂停），它将错过失效消息。`CONFIG_CACHE_TTL`（1 分钟）**只对已被之前的失效事件刷新过的条目**限制过期时长：这些条目距上次刷新最多 60 秒后会从 Redis 重新获取。然而，初始缓存条目使用不带 TTL 的 `.cache()` 创建，自身永不过期——如果某个配置的第一个失效事件被错过，该条目会持续提供过期数据，直到有后续事件到达、监听器终止（条目被驱逐）或进程重启。
+
+Source: [RedisConsistencyConfigService.kt:64-76](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt#L64)
 
 ### 委托模式
 

--- a/wiki/zh/guide/config-service.md
+++ b/wiki/zh/guide/config-service.md
@@ -284,15 +284,21 @@ spring:
       url: redis://localhost:6379
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-production}
+      namespace: ${cosky.namespace:cosky-{system}}
       config:
         config-id: ${spring.application.name}.yaml
+    service-registry:
+      auto-registration:
+        enabled: ${cosky.auto-registry:true}
+logging:
+  file:
+    name: logs/${spring.application.name}.log
 ```
 
 | 配置属性 | 描述 | 示例 |
 |---|---|---|
 | `spring.data.redis.url` | Redis 连接 URL | `redis://localhost:6379` |
-| `spring.cloud.cosky.namespace` | 用于配置隔离的命名空间 | `cosky-production` |
+| `spring.cloud.cosky.namespace` | 用于配置隔离的命名空间 | `cosky-{system}` |
 | `spring.cloud.cosky.config.config-id` | 要加载的 configId（通常为 `{app}.yaml`） | `order-service.yaml` |
 
 Source: [README.md:89](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L89)

--- a/wiki/zh/guide/config-service.md
+++ b/wiki/zh/guide/config-service.md
@@ -284,7 +284,7 @@ spring:
       url: redis://localhost:6379
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-{system}}
+      namespace: ${cosky.namespace:cosky-{default}}
       config:
         config-id: ${spring.application.name}.yaml
     service-registry:
@@ -298,10 +298,10 @@ logging:
 | 配置属性 | 描述 | 示例 |
 |---|---|---|
 | `spring.data.redis.url` | Redis 连接 URL | `redis://localhost:6379` |
-| `spring.cloud.cosky.namespace` | 用于配置隔离的命名空间 | `cosky-{system}` |
+| `spring.cloud.cosky.namespace` | 用于配置隔离的命名空间 | `cosky-{default}` |
 | `spring.cloud.cosky.config.config-id` | 要加载的 configId（通常为 `{app}.yaml`） | `order-service.yaml` |
 
-Source: [README.md:89](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L89)
+Source: [README.md:111](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L111)
 
 ## 回滚机制
 

--- a/wiki/zh/guide/dashboard.md
+++ b/wiki/zh/guide/dashboard.md
@@ -78,7 +78,7 @@ CoSky Dashboard 是一个基于 React 19、TypeScript、Radix UI 和 shadcn/ui�
 
 ![用户](/dashboard-user.png)
 
-用户管理支持创建用户、分配角色、修改密码，以及锁定/解锁账户。每行会展示反映账户状态的 `locked` 徽标。被管理员手动锁定的用户在解锁前无法登录或刷新令牌；root 用户（`cosky`）不可被锁定。锁定语义详见[安全与 RBAC](/guide/security-rbac#login-lockout-mechanism)。
+用户管理支持创建用户、分配角色、修改密码，以及锁定/解锁账户。每行会展示反映账户状态的 `locked` 徽标。被管理员手动锁定的用户在解锁前无法登录或刷新令牌；root 用户（`cosky`）不可被锁定。锁定语义详见[安全与 RBAC](/zh/guide/security-rbac#登录锁定机制)。
 
 ### 审计日志
 
@@ -181,8 +181,8 @@ flowchart LR
 
 ## 相关页面
 
-- [REST API Server](/guide/rest-api) -- Dashboard 消费的 API 端点
-- [安全与 RBAC](/guide/security-rbac) -- 认证和授权详情
+- [REST API Server](/zh/guide/rest-api) -- Dashboard 消费的 API 端点
+- [安全与 RBAC](/zh/guide/security-rbac) -- 认证和授权详情
 
 ## 参考
 

--- a/wiki/zh/guide/dashboard.md
+++ b/wiki/zh/guide/dashboard.md
@@ -4,13 +4,13 @@ title: Dashboard
 
 # Dashboard
 
-CoSky Dashboard 是一个基于 React 19、TypeScript 和 Ant Design 6 构建的现代化单页应用。它为所有 CoSky 功能提供了可视化管理界面：服务监控、配置管理、服务拓扑可视化、RBAC 管理、用户管理和审计日志查看。Dashboard 由 REST API 服务器直接作为静态资源提供服务，并通过 CoSky REST API 与后端通信。
+CoSky Dashboard 是一个基于 React 19、TypeScript、Radix UI 和 shadcn/ui（Tailwind CSS 4 样式）构建的现代化单页应用。它为所有 CoSky 功能提供了可视化管理界面：服务监控、配置管理、服务拓扑可视化、RBAC 管理、用户管理和审计日志查看。Dashboard 由 REST API 服务器直接作为静态资源提供服务，并通过 CoSky REST API 与后端通信。
 
 ## 一览
 
 | 方面 | 详情 | 关键文件 | 源码 |
 |--------|--------|----------|--------|
-| 前端应用 | React 19 SPA + Ant Design 6 | `dashboard/package.json` | [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json) |
+| 前端应用 | React 19 SPA + Radix UI + shadcn/ui | `dashboard/package.json` | [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json) |
 | SPA 路由服务 | 为所有 Dashboard 路由提供 `index.html` | `DashboardConfiguration.kt` | [cosky-rest-api/.../DashboardConfiguration.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/dashboard/DashboardConfiguration.kt#L30) |
 | API 客户端 | 从 OpenAPI 规范自动生成 | `dashboard/src/generated/` | [dashboard/package.json:12](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json#L12) |
 
@@ -18,18 +18,23 @@ CoSky Dashboard 是一个基于 React 19、TypeScript 和 Ant Design 6 构建的
 
 | 技术 | 版本 | 用途 |
 |-----------|---------|---------|
-| React | 19.2.6 | UI 框架 |
+| React | 19.2.6 | UI 框架（启用 React Compiler） |
 | TypeScript | ~6.0.3 | 类型安全开发 |
 | Vite | 8.0.16 | 构建工具和开发服务器 |
-| Ant Design | 6.3.7 | UI 组件库 |
+| Radix UI | 1.6.7 | 无头 UI 基础组件 |
+| shadcn/ui | 4.18.0 | 内置于源码的组件模式（`src/components/ui/`） |
+| Tailwind CSS | 4.3.3 | 原子化样式 |
+| lucide-react | 1.31.0 | 图标库 |
+| sonner | 2.0.8 | Toast 通知 |
 | React Router DOM | 7.15.1 | 客户端路由 |
 | @xyflow/react | 12.10.2 | 服务拓扑可视化 |
-| Monaco Editor | 0.55.1 | 配置文本编辑器 |
+| Monaco Editor | 0.55.1（通过 @monaco-editor/react 4.7.0） | 配置文本编辑器 |
 | @ahoo-wang/fetcher | 3.16.10 | 带 CoSec 认证的 HTTP 客户端 |
 | @ahoo-wang/fetcher-react | 3.16.10 | 用于 API 调用的 React Hooks |
 | @ahoo-wang/fetcher-cosec | 3.16.10 | CoSec 令牌刷新集成 |
-| @ahoo-wang/fetcher-viewer | 3.16.10 | 数据表格和筛选组件 |
+| @ahoo-wang/fetcher-storage | 3.16.10 | 令牌存储 |
 | @ahoo-wang/fetcher-generator | 3.16.10 | OpenAPI 代码生成 |
+| Playwright | 1.62.1 | 单元与端到端 UI 测试 |
 
 源码: [dashboard/package.json](https://github.com/Ahoo-Wang/CoSky/blob/main/dashboard/package.json)
 
@@ -73,13 +78,17 @@ CoSky Dashboard 是一个基于 React 19、TypeScript 和 Ant Design 6 构建的
 
 ![用户](/dashboard-user.png)
 
-用户管理支持创建用户、分配角色、修改密码和解锁被锁定的账户。
+用户管理支持创建用户、分配角色、修改密码，以及锁定/解锁账户。每行会展示反映账户状态的 `locked` 徽标。被管理员手动锁定的用户在解锁前无法登录或刷新令牌；root 用户（`cosky`）不可被锁定。锁定语义详见[安全与 RBAC](/guide/security-rbac#login-lockout-mechanism)。
 
 ### 审计日志
 
 ![审计日志](/dashboard-audit-log.png)
 
-审计日志页面显示所有审计操作的分页列表，包含操作者、IP、路径、操作、状态和时间戳列。
+审计日志页面显示所有审计操作的分页列表，包含操作者、IP、资源、操作、状态和时间戳列，并支持将审计日志导出为 CSV 文件（`GET /v1/audit-log/export`）。
+
+### 导航搜索
+
+侧边栏提供键盘优先的导航搜索。在输入框之外按下 `/` 即可聚焦搜索框，按名称或描述筛选页面，使用 `ArrowUp`/`ArrowDown` 移动，按 `Enter` 跳转。
 
 ### 登录
 
@@ -103,10 +112,10 @@ flowchart TD
     end
 
     subgraph "Redis"
-        UserRedis["用户索引<br>system:user_idx"]
+        UserRedis["用户索引<br>cosky-{system}:user_idx"]
         ConfigRedis["配置<br>命名空间键"]
         ServiceRedis["服务<br>命名空间键"]
-        AuditRedis["审计日志<br>system:audit:log"]
+        AuditRedis["审计日志<br>cosky-{system}:audit:log"]
     end
 
     SPA -->|"HTML/JS/CSS"| DashboardConfig

--- a/wiki/zh/guide/deployment-kubernetes.md
+++ b/wiki/zh/guide/deployment-kubernetes.md
@@ -76,6 +76,10 @@ spec:
 
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
+::: tip 镜像标签
+仓库内置清单将镜像标签固定为 `5.3.5`（[k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)），而当前发布版本为 `5.7.2`（[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)）。可覆盖镜像（例如 Docker Hub 上的 `ahoowang/cosky:latest`）以运行最新版本。
+:::
+
 ## 集群化 Redis 部署
 
 对于使用 Redis Cluster 的生产环境，请使用集群清单，该清单从 Kubernetes Secret 读取连接详情：

--- a/wiki/zh/guide/deployment-kubernetes.md
+++ b/wiki/zh/guide/deployment-kubernetes.md
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           ports:
             - name: http
               containerPort: 8080
@@ -77,7 +77,7 @@ spec:
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
 ::: tip 镜像标签
-仓库内置清单将镜像标签固定为 `5.3.5`（[k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)），而当前发布版本为 `5.7.2`（[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)）。可覆盖镜像（例如 Docker Hub 上的 `ahoowang/cosky:latest`）以运行最新版本。
+下方清单使用当前发布版本 `5.7.2`（[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)）。仓库内置清单（[k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)）仍固定为较旧的 `5.3.5` 标签——建议使用当前发布版本，或 Docker Hub 上的 `ahoowang/cosky:latest`。
 :::
 
 ## 集群化 Redis 部署
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           env:
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:

--- a/wiki/zh/guide/deployment-standalone.md
+++ b/wiki/zh/guide/deployment-standalone.md
@@ -8,32 +8,33 @@ title: "Standalone Deployment"
 
 独立部署选项允许您直接在主机上运行 CoSky，无需 Docker 或 Kubernetes。这种方式非常适合开发环境、小规模部署或没有容器运行时的环境。独立发行版将 CoSky 打包为一个包含启动脚本、配置文件和内置 Dashboard UI 的自包含应用程序。
 
-## 下载并解压
+## 构建并解压
 
-下载最新版本的压缩包并解压：
+GitHub Releases 并未发布预构建的压缩包，因此需要从源码构建独立发行版（需要 JDK 17+）：
 
 ```bash
-# 下载最新版本
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# 构建发行版压缩包
+./gradlew :cosky-rest-api:distTar
 
 # 解压
-tar -xvf cosky-server.tar
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
 
 # 进入目录
-cd cosky-server
+cd cosky-rest-api-5.7.2
 ```
+
+发行版会将 `dashboard/dist` 中的 Dashboard 静态文件打包到 `ui/` 目录。如果该目录不存在，请先执行 `cd dashboard && pnpm install && pnpm build` 构建 Dashboard。
 
 解压后的目录结构包含：
 
 ```
-cosky-server/
+cosky-rest-api-5.7.2/
   bin/
-    cosky              # 启动脚本 (Unix)
+    cosky-rest-api     # 启动脚本 (Unix)
   config/
     application.yaml   # 应用程序配置
     bootstrap.yaml     # 引导配置
-  dashboard/
-    dist/              # Dashboard UI 静态文件
+  ui/                  # Dashboard UI 静态文件
   lib/
     *.jar              # 运行时依赖
 ```
@@ -43,7 +44,7 @@ cosky-server/
 使用必需的 Redis 连接参数启动 CoSky：
 
 ```bash
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 所有 Spring Boot 属性都可以使用 `--property=value` 格式作为命令行参数传入。也可以将它们设置为环境变量或直接编辑配置文件。
@@ -60,7 +61,7 @@ flowchart TD
     C -->|"是"| E["Kubernetes 部署"]
     C -->|"否"| F["Docker / Docker Compose"]
     D --> G{"JDK 17+<br>已安装?"}
-    G -->|"是"| H["下载压缩包<br>bin/cosky"]
+    G -->|"是"| H["构建压缩包<br>bin/cosky-rest-api"]
     G -->|"否"| I["安装 JDK 17+"]
     I --> H
     H --> J{"Redis<br>可用?"}
@@ -104,7 +105,7 @@ spring:
           weight: 8
   web:
     resources:
-      static-locations: file:./dashboard/dist/
+      static-locations: file:./ui/
 cosky:
   security:
     enabled: true
@@ -203,7 +204,7 @@ sequenceDiagram
     participant R as Redis
     participant US as cosky（超级用户）
 
-    OS->>JVM: bin/cosky --server.port=8080
+    OS->>JVM: bin/cosky-rest-api --server.port=8080
     JVM->>SB: 启动应用上下文
     SB->>SB: 加载 bootstrap.yaml
     SB->>SB: 解析应用名称: cosky-rest-api
@@ -266,7 +267,7 @@ flowchart TD
 
 ```bash
 export JAVA_OPTS="-Xms512M -Xmx512M -XX:+UseZGC"
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
 
 ## 服务发现与自注册
@@ -310,7 +311,7 @@ logging:
 要更改日志位置，请覆盖 `logging.file.name` 属性：
 
 ```bash
-bin/cosky --logging.file.name=/var/log/cosky/cosky.log
+bin/cosky-rest-api --logging.file.name=/var/log/cosky/cosky.log
 ```
 
 ## 相关页面

--- a/wiki/zh/guide/deployment-standalone.md
+++ b/wiki/zh/guide/deployment-standalone.md
@@ -13,6 +13,10 @@ title: "Standalone Deployment"
 GitHub Releases 并未发布预构建的压缩包，因此需要从源码构建独立发行版（需要 JDK 17+）：
 
 ```bash
+# 先构建 Dashboard（dashboard/dist 已被 gitignore；
+# 缺少此步骤打包出的发行版将没有 Web UI）
+cd dashboard && pnpm install && pnpm build && cd ..
+
 # 构建发行版压缩包
 ./gradlew :cosky-rest-api:distTar
 
@@ -23,7 +27,7 @@ tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
 cd cosky-rest-api-5.7.2
 ```
 
-发行版会将 `dashboard/dist` 中的 Dashboard 静态文件打包到 `ui/` 目录。如果该目录不存在，请先执行 `cd dashboard && pnpm install && pnpm build` 构建 Dashboard。
+发行版会将 `dashboard/dist` 中的 Dashboard 静态文件打包到 `ui/` 目录。
 
 解压后的目录结构包含：
 

--- a/wiki/zh/guide/getting-started.md
+++ b/wiki/zh/guide/getting-started.md
@@ -63,6 +63,7 @@ val coskyVersion = "5.7.2"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
@@ -80,6 +81,13 @@ dependencies {
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
             <artifactId>cosky-bom</artifactId>
+            <version>${cosky.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.ahoo.cosky</groupId>
+            <artifactId>cosky-dependencies</artifactId>
             <version>${cosky.version}</version>
             <type>pom</type>
             <scope>import</scope>

--- a/wiki/zh/guide/getting-started.md
+++ b/wiki/zh/guide/getting-started.md
@@ -62,9 +62,9 @@ graph LR
 val coskyVersion = "5.7.2"
 
 dependencies {
-    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery")
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 }
 ```
@@ -79,7 +79,7 @@ dependencies {
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>cosky-dependencies</artifactId>
+            <artifactId>cosky-bom</artifactId>
             <version>${cosky.version}</version>
             <type>pom</type>
             <scope>import</scope>
@@ -89,11 +89,11 @@ dependencies {
 <dependencies>
     <dependency>
         <groupId>me.ahoo.cosky</groupId>
-        <artifactId>spring-cloud-starter-cosky-config</artifactId>
+        <artifactId>cosky-spring-cloud-starter-config</artifactId>
     </dependency>
     <dependency>
         <groupId>me.ahoo.cosky</groupId>
-        <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
+        <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
     </dependency>
     <dependency>
         <groupId>org.springframework.cloud</groupId>
@@ -106,27 +106,25 @@ dependencies {
 
 ### 第 2 步：配置 Bootstrap
 
-创建 `src/main/resources/bootstrap.yaml`：
+创建 `src/main/resources/bootstrap.yaml`。下面是内置示例提供者（example provider）使用的配置：
 
 ```yaml
+server:
+  port: 8099
 spring:
   application:
-    name: ${service.name:my-service}
-  data:
-    redis:
-      url: redis://localhost:6379
+    name: ${service.name:example-provider}
   cloud:
     cosky:
-      namespace: ${cosky.namespace:cosky-{default}}
+      namespace: ${cosky.namespace:dev}
       config:
         config-id: ${spring.application.name}.yaml
-    service-registry:
-      auto-registration:
-        enabled: ${cosky.auto-registry:true}
 logging:
   file:
     name: logs/${spring.application.name}.log
 ```
+
+该示例依赖 Spring Boot 默认的 Redis 连接（`localhost:6379`）；如果您的 Redis 实例在其他地址运行，请显式设置 `spring.data.redis.url`。服务自动注册默认启用（`spring.cloud.service-registry.auto-registration.enabled`）。
 
 | 属性 | 默认值 | 说明 |
 |----------|---------|-------------|
@@ -134,7 +132,7 @@ logging:
 | `spring.cloud.cosky.namespace` | `cosky-{default}` | 服务/配置隔离的命名空间（[CoSkyProperties.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt#L30)） |
 | `spring.cloud.cosky.config.config-id` | `${spring.application.name}.yaml` | 要加载的配置文件 ID（[CoSkyConfigAutoConfiguration.kt:48](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L48)） |
 | `spring.cloud.service-registry.auto-registration.enabled` | `true` | 启动时自动注册服务 |
-| `spring.cloud.cosky.config.file-extension` | `yaml` | 配置查找的默认文件扩展名（[CoSkyConfigProperties.kt:27](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L27)） |
+| `spring.cloud.cosky.config.file-extension` | `yaml` | 配置查找的默认文件扩展名（[CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28)） |
 
 源码：[examples/cosky-service-provider/src/main/resources/bootstrap.yaml](https://github.com/Ahoo-Wang/CoSky/blob/main/examples/cosky-service-provider/src/main/resources/bootstrap.yaml)
 

--- a/wiki/zh/guide/index.md
+++ b/wiki/zh/guide/index.md
@@ -12,7 +12,7 @@ description: Explore CoSky's architecture, features, and documentation for high-
 | 特性 | 说明 | 源码 |
 |---------|-------------|--------|
 | **服务发现** | 通过客户端心跳自动续约，注册、发现和管理服务实例。支持加权负载均衡和服务拓扑。 | [ServiceRegistry.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceRegistry.kt#L24), [ServiceDiscovery.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceDiscovery.kt#L24) |
-| **配置管理** | 支持版本历史（最近 10 个版本）、回滚和文件导入/导出的动态配置。变更通过 Redis PubSub 即时传播。 | [ConfigService.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigService.kt#L24), [ConfigRollback.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigRollback.kt#L24) |
+| **配置管理** | 支持版本历史与回滚、文件导入/导出的动态配置。变更通过 Redis PubSub 即时传播。 | [ConfigService.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigService.kt#L24), [ConfigRollback.kt:24](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/ConfigRollback.kt#L24) |
 | **一致性缓存** | 通过 Redis PubSub 保持同步的本地进程缓存，相比直接读取 Redis 实现 250 倍至 800 倍的性能提升。 | [RedisConsistencyConfigService](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-config/src/main/kotlin/me/ahoo/cosky/config/redis/RedisConsistencyConfigService.kt), [ConsistencyRedisServiceDiscovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/ConsistencyRedisServiceDiscovery.kt) |
 | **Spring Cloud 集成** | 配置和发现的即用型 Starter。通过 Spring Boot `@AutoConfiguration` 自动配置。 | [CoSkyConfigAutoConfiguration.kt:43](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L43), [CoSkyDiscoveryAutoConfiguration.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L47) |
 | **加权负载均衡** | 与服务发现集成的二进制权重随机负载均衡器，用于高效的实例选择。 | [CoSkyDiscoveryAutoConfiguration.kt:105](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L105) |
@@ -27,8 +27,8 @@ description: Explore CoSky's architecture, features, and documentation for high-
 graph TB
     subgraph Applications["应用程序"]
         style Applications fill:#161b22,stroke:#30363d,color:#e6edf3
-        A["Spring Boot 应用 1"] --> |使用| SC_C["spring-cloud-starter-cosky-config"]
-        A --> |使用| SC_D["spring-cloud-starter-cosky-discovery"]
+        A["Spring Boot 应用 1"] --> |使用| SC_C["cosky-spring-cloud-starter-config"]
+        A --> |使用| SC_D["cosky-spring-cloud-starter-discovery"]
         B["Spring Boot 应用 2"] --> |使用| SC_C
         B --> |使用| SC_D
     end
@@ -79,8 +79,8 @@ graph LR
         style Modules fill:#161b22,stroke:#30363d,color:#e6edf3
         CORE["cosky-core"] --> CONFIG["cosky-config"]
         CORE --> DISCOVERY["cosky-discovery"]
-        CONFIG --> SCC["spring-cloud-starter-cosky-config"]
-        DISCOVERY --> SCD["spring-cloud-starter-cosky-discovery"]
+        CONFIG --> SCC["cosky-spring-cloud-starter-config"]
+        DISCOVERY --> SCD["cosky-spring-cloud-starter-discovery"]
         SCC --> REST["cosky-rest-api"]
         SCD --> REST
         SC_CORE["cosky-spring-cloud-core"] --> SCC

--- a/wiki/zh/guide/installation.md
+++ b/wiki/zh/guide/installation.md
@@ -57,6 +57,7 @@ val coskyVersion = "5.7.2"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
     implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
@@ -85,6 +86,13 @@ dependencies {
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>me.ahoo.cosky</groupId>
+                <artifactId>cosky-dependencies</artifactId>
+                <version>${cosky.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -105,7 +113,7 @@ dependencies {
 </project>
 ```
 
-源码：[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14), [README.md:46-87](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L46-L87)
+源码：[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14), [README.md:46-108](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L46-L108)
 
 ### 可用构件
 
@@ -113,7 +121,8 @@ dependencies {
 |----------|---------|--------|
 | `cosky-spring-cloud-starter-config` | Spring Cloud 配置加载和实时刷新 | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
 | `cosky-spring-cloud-starter-discovery` | Spring Cloud 服务注册和发现 | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
-| `cosky-bom` | 用于依赖版本管理的物料清单 | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
+| `cosky-bom` | 物料清单 —— 管理 CoSky 模块版本 | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
+| `cosky-dependencies` | 版本目录 —— 管理 Spring Boot / Spring Cloud / CosID / Simba / CoSec 版本（无版本号的 `spring-cloud-starter-loadbalancer` 依赖需要它） | [cosky-dependencies](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-dependencies) |
 
 ## REST API 服务器安装
 
@@ -148,7 +157,7 @@ bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:
 
 要重新初始化密码，请在配置中设置 `enforce-init-super-user: true`。
 
-源码：[cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44)、[cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13)、[README.md:242](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L242)
+源码：[cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44)、[cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13)、[README.md:267](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L267)
 
 ### 方式 2：Docker
 
@@ -185,7 +194,7 @@ services:
       - redis
 ```
 
-源码：[README.md:132-137](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L132-L137)
+源码：[README.md:159-163](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L159-L163)
 
 ### 方式 3：Kubernetes
 
@@ -220,7 +229,7 @@ spec:
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           startupProbe:
             httpGet:
               port: http
@@ -255,7 +264,7 @@ spec:
           name: volume-localtime
 ```
 
-> **注意：** 仓库内的清单将镜像标签固定为 `5.3.5`，而当前发布版本为 `5.7.2`。您可能需要覆盖镜像标签——例如使用 Docker Hub 上的 `ahoowang/cosky:5.7.2` 或其他镜像仓库的相应标签。
+> **注意：** 上述示例使用当前发布版本 `5.7.2`。仓库内置清单（[k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)）仍固定为较旧的 `5.3.5` 标签——建议使用当前发布版本，或 Docker Hub 上的 `ahoowang/cosky:latest`。
 
 源码：[k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -304,7 +313,7 @@ spec:
               value: 30s
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.7.2
           startupProbe:
             httpGet:
               port: http
@@ -496,7 +505,7 @@ REST API 服务器运行后，通过以下地址访问基于 Web 的管理界面
 - 服务拓扑可视化
 - 导入/导出功能（包括 Nacos 迁移）
 
-源码：[README.md:206-219](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L206-L219)
+源码：[README.md:238-246](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L238-L246)
 
 ## 参考
 

--- a/wiki/zh/guide/installation.md
+++ b/wiki/zh/guide/installation.md
@@ -56,9 +56,9 @@ flowchart TD
 val coskyVersion = "5.7.2"
 
 dependencies {
-    implementation(platform("me.ahoo.cosky:cosky-dependencies:${coskyVersion}"))
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-config")
-    implementation("me.ahoo.cosky:spring-cloud-starter-cosky-discovery")
+    implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-config")
+    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 }
 ```
@@ -80,7 +80,7 @@ dependencies {
         <dependencies>
             <dependency>
                 <groupId>me.ahoo.cosky</groupId>
-                <artifactId>cosky-dependencies</artifactId>
+                <artifactId>cosky-bom</artifactId>
                 <version>${cosky.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -91,11 +91,11 @@ dependencies {
     <dependencies>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-config</artifactId>
+            <artifactId>cosky-spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
             <groupId>me.ahoo.cosky</groupId>
-            <artifactId>spring-cloud-starter-cosky-discovery</artifactId>
+            <artifactId>cosky-spring-cloud-starter-discovery</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -111,8 +111,8 @@ dependencies {
 
 | 构件 | 用途 | 模块 |
 |----------|---------|--------|
-| `spring-cloud-starter-cosky-config` | Spring Cloud 配置加载和实时刷新 | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
-| `spring-cloud-starter-cosky-discovery` | Spring Cloud 服务注册和发现 | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
+| `cosky-spring-cloud-starter-config` | Spring Cloud 配置加载和实时刷新 | [cosky-spring-cloud-starter-config](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config) |
+| `cosky-spring-cloud-starter-discovery` | Spring Cloud 服务注册和发现 | [cosky-spring-cloud-starter-discovery](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery) |
 | `cosky-bom` | 用于依赖版本管理的物料清单 | [cosky-bom](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-bom) |
 
 ## REST API 服务器安装
@@ -121,19 +121,24 @@ REST API 服务器提供管理控制台、REST 端点、安全（RBAC）和审�
 
 ### 方式 1：独立 JAR
 
-下载最新版本并直接运行：
+GitHub Releases 不发布预构建的归档文件，因此需要从源码构建服务器发行包（需要 JDK 17）：
 
 ```bash
-# 下载 cosky-server
-wget https://github.com/Ahoo-Wang/cosky/releases/latest/download/cosky-server.tar
+# （可选）先构建控制台前端，以便将 Web UI 打包进发行包
+cd dashboard && pnpm install && pnpm build && cd ..
 
-# 解压
-tar -xvf cosky-server.tar
-cd cosky-server
+# 构建发行包归档
+./gradlew :cosky-rest-api:distTar
+
+# 解压（归档文件名包含版本号）
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.7.2.tar
+cd cosky-rest-api-5.7.2
 
 # 使用 Redis 连接运行
-bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
+bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 ```
+
+发行包包含 `bin/` 启动脚本、`lib/` 依赖库、`config/` 配置文件，以及存放控制台静态资源的 `ui/` 目录（通过 `spring.web.resources.static-locations: file:./ui/` 提供访问）。
 
 首次启动时，CoSky 会初始化超级用户并将生成的密码打印到控制台：
 
@@ -143,7 +148,7 @@ bin/cosky --server.port=8080 --spring.data.redis.url=redis://localhost:6379
 
 要重新初始化密码，请在配置中设置 `enforce-init-super-user: true`。
 
-源码：[README.md:119-127](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L119-L127)
+源码：[cosky-rest-api/build.gradle.kts:36-44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/build.gradle.kts#L36-L44)、[cosky-rest-api/src/dist/config/application.yaml:13](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/application.yaml#L13)、[README.md:242](https://github.com/Ahoo-Wang/CoSky/blob/main/README.md#L242)
 
 ### 方式 2：Docker
 
@@ -204,20 +209,18 @@ spec:
     metadata:
       labels:
         app: cosky
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
-        - name: cosky
-          image: ahoowang/cosky:latest
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-          env:
+        - env:
             - name: SPRING_DATA_REDIS_HOST
               value: redis-uri:6379
             - name: SPRING_DATA_REDIS_PASSWORD
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
           startupProbe:
             httpGet:
               port: http
@@ -230,21 +233,29 @@ spec:
             httpGet:
               port: http
               path: /actuator/health/liveness
+          name: cosky
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
           resources:
-            requests:
-              cpu: 250m
-              memory: 1024Mi
             limits:
               cpu: "1"
               memory: 1280Mi
+            requests:
+              cpu: 250m
+              memory: 1024Mi
           volumeMounts:
-            - name: volume-localtime
-              mountPath: /etc/localtime
+            - mountPath: /etc/localtime
+              name: volume-localtime
       volumes:
-        - name: volume-localtime
-          hostPath:
+        - hostPath:
             path: /etc/localtime
+            type: ""
+          name: volume-localtime
 ```
+
+> **注意：** 仓库内的清单将镜像标签固定为 `5.3.5`，而当前发布版本为 `5.7.2`。您可能需要覆盖镜像标签——例如使用 Docker Hub 上的 `ahoowang/cosky:5.7.2` 或其他镜像仓库的相应标签。
 
 源码：[k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -268,11 +279,13 @@ spec:
     metadata:
       labels:
         app: cosky
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
-        - name: cosky
-          image: ahoowang/cosky:latest
-          env:
+        - env:
+            - name: LANG
+              value: C.utf8
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:
                 secretKeyRef:
@@ -289,6 +302,41 @@ spec:
               value: "true"
             - name: SPRING_DATA_REDIS_LETTUCE_CLUSTER_REFRESH_PERIOD
               value: 30s
+            - name: TZ
+              value: Asia/Shanghai
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.3.5
+          startupProbe:
+            httpGet:
+              port: http
+              path: /actuator/health
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /actuator/health/readiness
+          livenessProbe:
+            httpGet:
+              port: http
+              path: /actuator/health/liveness
+          name: cosky
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1280Mi
+            requests:
+              cpu: 250m
+              memory: 1024Mi
+          volumeMounts:
+            - mountPath: /etc/localtime
+              name: volume-localtime
+      volumes:
+        - hostPath:
+            path: /etc/localtime
+            type: ""
+          name: volume-localtime
 ```
 
 源码：[k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml)
@@ -365,8 +413,8 @@ CoSky 的关键配置属性：
 | `spring.cloud.cosky.namespace` | `cosky-{default}` | 服务和配置的隔离命名空间 | [CoSkyProperties.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt#L30) |
 | `spring.cloud.cosky.config.enabled` | `true` | 启用从 Redis 加载配置 | [CoSkyConfigProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L26) |
 | `spring.cloud.cosky.config.config-id` | `${spring.application.name}.yaml` | 要加载的配置文件 ID | [CoSkyConfigAutoConfiguration.kt:48](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigAutoConfiguration.kt#L48) |
-| `spring.cloud.cosky.config.file-extension` | `yaml` | 默认文件扩展名 | [CoSkyConfigProperties.kt:27](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L27) |
-| `spring.cloud.cosky.config.timeout` | `2s` | 配置加载超时时间 | [CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28) |
+| `spring.cloud.cosky.config.file-extension` | `yaml` | 默认文件扩展名 | [CoSkyConfigProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L28) |
+| `spring.cloud.cosky.config.timeout` | `2s` | 配置加载超时时间 | [CoSkyConfigProperties.kt:29](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt#L29) |
 | `spring.cloud.cosky.discovery.enabled` | `true` | 启用服务发现 | [CoSkyDiscoveryProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt#L26) |
 | `spring.cloud.cosky.discovery.timeout` | `2s` | 发现操作超时时间 | [CoSkyDiscoveryProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt#L28) |
 | `spring.cloud.service-registry.auto-registration.enabled` | `true` | 启动时自动注册服务 | [bootstrap.yaml:9](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/dist/config/bootstrap.yaml#L9) |
@@ -381,7 +429,7 @@ CoSky 的关键配置属性：
 |----------|---------|-------------|--------|
 | 实例 TTL | `60s` | 实例在被视为过期前的存活时间 | [RegistryProperties.kt:26](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RegistryProperties.kt#L26) |
 | 续约周期 | `10s` | 实例发送心跳以续约 TTL 的频率 | [RenewProperties.kt:28](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L28) |
-| 续约初始延迟 | `1s` | 注册后首次心跳前的延迟时间 | [RenewProperties.kt:25](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L25) |
+| 续约初始延迟 | `1s` | 注册后首次心跳前的延迟时间 | [RenewProperties.kt:23](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewProperties.kt#L23) |
 
 ```mermaid
 %%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#2d333b','primaryBorderColor':'#6d5dfc','primaryTextColor':'#e6edf3','lineColor':'#8b949e','secondaryColor':'#161b22','tertiaryColor':'#161b22'}}}%%

--- a/wiki/zh/guide/load-balancers.md
+++ b/wiki/zh/guide/load-balancers.md
@@ -269,7 +269,7 @@ val instance = Instance.asInstance(
     metadata = mapOf("version" to "v2")
 )
 
-serviceRegistry.register(instance = instance).block()
+serviceRegistry.register(serviceInstance = instance).block()
 ```
 
 权重存储在 Redis 哈希的 `weight` 字段中，由 `ServiceInstanceCodec` 解码 ([ServiceInstanceCodec.kt:32](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/ServiceInstanceCodec.kt#L32))。

--- a/wiki/zh/guide/rest-api.md
+++ b/wiki/zh/guide/rest-api.md
@@ -92,12 +92,13 @@ fun main(args: Array<String>) {
 
 | 方法 | 路径 | 描述 | 控制器方法 | 源码 |
 |--------|------|-------------|-------------------|--------|
-| GET | `/v1/users` | 列出所有用户及其角色 | `query` | [UserController.kt:42](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L42) |
-| POST | `/v1/users/{username}` | 添加新用户 | `addUser` | [UserController.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L52) |
-| DELETE | `/v1/users/{username}` | 移除用户 | `removeUser` | [UserController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L62) |
-| PATCH | `/v1/users/{username}/password` | 修改密码 | `changePwd` | [UserController.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L47) |
-| PATCH | `/v1/users/{username}/role` | 绑定角色到用户 | `bindRole` | [UserController.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L57) |
-| DELETE | `/v1/users/{username}/unlock` | 解锁被锁定的用户 | `unlock` | [UserController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L67) |
+| GET | `/v1/users` | 列出所有用户及其角色 | `query` | [UserController.kt:44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L44) |
+| POST | `/v1/users/{username}` | 添加新用户 | `addUser` | [UserController.kt:54](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L54) |
+| DELETE | `/v1/users/{username}` | 移除用户 | `removeUser` | [UserController.kt:64](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L64) |
+| PATCH | `/v1/users/{username}/password` | 修改密码 | `changePwd` | [UserController.kt:49](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L49) |
+| PATCH | `/v1/users/{username}/role` | 绑定角色到用户 | `bindRole` | [UserController.kt:59](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L59) |
+| PUT | `/v1/users/{username}/lock` | 锁定用户（手动锁定；root 用户不可被锁定） | `lock` | [UserController.kt:68](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L68) |
+| DELETE | `/v1/users/{username}/unlock` | 解锁被锁定的用户 | `unlock` | [UserController.kt:74](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L74) |
 
 ### 角色端点
 
@@ -112,7 +113,8 @@ fun main(args: Array<String>) {
 
 | 方法 | 路径 | 描述 | 控制器方法 | 源码 |
 |--------|------|-------------|-------------------|--------|
-| GET | `/v1/audit-log` | 查询审计日志 | `queryLog` | [AuditLogController.kt:32](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L32) |
+| GET | `/v1/audit-log` | 查询审计日志 | `queryLog` | [AuditLogController.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L40) |
+| GET | `/v1/audit-log/export` | 导出审计日志为 CSV | `exportLog` | [AuditLogController.kt:51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogController.kt#L51) |
 
 ## 时序图
 
@@ -239,12 +241,12 @@ cosky:
     enabled: true                    # 启用/禁用安全
     audit-log:
       action: write                  # 审计日志过滤："write"、"read" 或 "rw"
-    enforce-init-super-user: false   # 启动时强制重新初始化超级用户
+    enforce-init-super-user: ${cosky.super.init:false}   # 启动时强制重新初始化超级用户
 
 cosec:
   jwt:
     algorithm: hmac256               # JWT 签名算法
-    secret: ${cosky.security.key}    # JWT 密钥
+    secret: ${cosky.security.key:FyN0Igd80Gas3stTavArGKOYnS9uLWGA$}    # JWT 密钥
     token-validity:
       access: 15m                    # 访问令牌 TTL
       refresh: 3H                    # 刷新令牌 TTL

--- a/wiki/zh/guide/rest-api.md
+++ b/wiki/zh/guide/rest-api.md
@@ -269,8 +269,8 @@ simba:
 
 ## 相关页面
 
-- [安全与 RBAC](/guide/security-rbac) -- 认证、授权和基于角色的访问控制
-- [Dashboard](/guide/dashboard) -- CoSky 管理 UI
+- [安全与 RBAC](/zh/guide/security-rbac) -- 认证、授权和基于角色的访问控制
+- [Dashboard](/zh/guide/dashboard) -- CoSky 管理 UI
 
 ## 参考
 

--- a/wiki/zh/guide/security-rbac.md
+++ b/wiki/zh/guide/security-rbac.md
@@ -307,8 +307,8 @@ classDiagram
 
 ## 相关页面
 
-- [REST API Server](/guide/rest-api) -- API 端点和服务器架构
-- [Dashboard](/guide/dashboard) -- CoSky 管理 UI
+- [REST API Server](/zh/guide/rest-api) -- API 端点和服务器架构
+- [Dashboard](/zh/guide/dashboard) -- CoSky 管理 UI
 
 ## 参考
 

--- a/wiki/zh/guide/security-rbac.md
+++ b/wiki/zh/guide/security-rbac.md
@@ -63,7 +63,7 @@ CoSky 支持两种认证方式：
 
 ### 登录锁定机制
 
-`UserService.login()` 实现了渐进式账户锁定以防止暴力破解攻击。所有锁定状态变更都在原子性 Lua 脚本 `user_state.lua` 中执行（操作：`login-attempt`、`login-success`、`lock`、`remove`），因此并发登录不会破坏计数器。
+`UserService.login()` 实现了渐进式账户锁定以防止暴力破解攻击。每个锁定状态变更（`login-attempt`、`login-success`、`lock`、`remove`）都以单次原子性 `user_state.lua` 脚本调用执行，因此单个计数更新不会被并发登录破坏。注意，一次完整登录包含两次独立的脚本调用（先 attempt，密码校验通过后再 success），而 `unlock()` 会直接删除锁定键，因此端到端的登录序列并非一个原子整体。
 
 - **最大失败次数**：10 次（`MAX_LOGIN_ERROR_TIMES`）
 - **锁定追踪**：Redis 键（`cosky-{system}:login_lock:{username}`）在每次登录尝试时递增，在成功登录时删除。当计数未超过阈值时，脚本会在每次尝试时将键的 TTL 刷新为 15 分钟（`LOGIN_LOCK_EXPIRE`），因此冻结实际会在最后一次计数尝试的 15 分钟后解除。
@@ -251,7 +251,7 @@ classDiagram
 - **用户索引**：Redis Hash（`cosky-{system}:user_idx`），将用户名映射到 SHA-256 密码哈希。
 - **角色绑定**：Redis Set（`cosky-{system}:user_role_bind:{username}`），存储分配给每个用户的角色名称。
 - **密码哈希**：使用 Guava 的 `Hashing.sha256()` 进行 UTF-8 编码。
-- **登录锁定**：参见上方[登录锁定机制](#登录锁定机制)。所有锁定状态变更都由 `user_state.lua` 脚本原子执行。
+- **登录锁定**：参见上方[登录锁定机制](#登录锁定机制)。每个锁定状态变更都由 `user_state.lua` 脚本原子执行。
 - **用户列表**：`query()` 返回每个用户的角色绑定及 `locked` 属性（手动锁定或超过失败次数阈值时为 `true`）。
 - **删除保护**：root 用户（`cosky`）既不可被删除，也不可被锁定。
 - **Root 初始化**：`initRoot(enforce)` 在 root 用户不存在时创建 `cosky` 超级用户并生成随机密码；`enforce = true` 会先删除已有 root，强制重新初始化。

--- a/wiki/zh/guide/security-rbac.md
+++ b/wiki/zh/guide/security-rbac.md
@@ -4,7 +4,7 @@ title: Security & RBAC
 
 # 安全与 RBAC
 
-CoSky 实现了全面的三层安全模型 -- **认证**、**授权**和**审计** -- 基于 [CoSec](https://github.com/Ahoo-Wang/CoSec) 安全框架构建。用户凭据使用 SHA-256 哈希存储在 Redis 中。授权结合了策略引擎（CoSec 策略 JSON）和命名空间范围的 RBAC。所有操作都会被审计并持久化到 Redis List 中以供查询。
+CoSky 实现了全面的三层安全模型 -- **认证**、**授权**和**审计** -- 基于 [CoSec](https://github.com/Ahoo-Wang/CoSec) 安全框架构建。用户凭据使用 SHA-256 哈希存储在 Redis 中。授权结合了策略引擎（CoSec 策略 JSON）和命名空间范围的 RBAC。操作会被审计（默认仅写操作，可配置）并持久化到 Redis List 中以供查询。
 
 ## 一览
 
@@ -52,7 +52,7 @@ flowchart LR
 CoSky 支持两种认证方式：
 
 1. **UserPasswordAuthentication** -- 使用 SHA-256 哈希凭据（存储在 Redis 中）验证用户名/密码。成功时，`UserService.login()` 方法返回包含用户角色绑定的 `SimplePrincipal`。
-2. **RefreshTokenAuthentication** -- 接受访问/刷新令牌对，并通过 CoSec 的 `TokenVerifier` 验证刷新令牌。成功时返回新的令牌对。
+2. **RefreshTokenAuthentication** -- 接受访问/刷新令牌对，并通过 CoSec 的 `TokenVerifier` 验证刷新令牌。验证通过后会调用 `UserService.ensureUnlocked()`，因此已被锁定的账户无法再刷新令牌。成功时返回新的令牌对。
 
 ### AuthenticateController 端点
 
@@ -63,16 +63,17 @@ CoSky 支持两种认证方式：
 
 ### 登录锁定机制
 
-`UserService.login()` 实现了渐进式账户锁定以防止暴力破解攻击：
+`UserService.login()` 实现了渐进式账户锁定以防止暴力破解攻击。所有锁定状态变更都在原子性 Lua 脚本 `user_state.lua` 中执行（操作：`login-attempt`、`login-success`、`lock`、`remove`），因此并发登录不会破坏计数器。
 
 - **最大失败次数**：10 次（`MAX_LOGIN_ERROR_TIMES`）
-- **基础锁定时长**：15 分钟（`LOGIN_LOCK_EXPIRE`）
-- **最大锁定时长**：3 天（`MAX_LOGIN_LOCK_EXPIRE`）
-- **指数退避**：`lockoutDuration = baseLockout * max(tryCount / maxErrorTimes, 1)`，不超过最大值。
-- **锁定追踪**：Redis 键（`system:login_lock:{username}`）在每次失败尝试时递增，在成功登录时删除。
-- **解锁**：管理员可通过 `DELETE /v1/users/{username}/unlock` 解锁用户。
+- **锁定追踪**：Redis 键（`cosky-{system}:login_lock:{username}`）在每次登录尝试时递增，在成功登录时删除。当计数未超过阈值时，脚本会在每次尝试时将键的 TTL 刷新为 15 分钟（`LOGIN_LOCK_EXPIRE`），因此冻结实际会在最后一次计数尝试的 15 分钟后解除。
+- **冻结提示**：当计数超过 10 次后，登录将被拒绝直到键过期。错误消息中的冻结时长按渐进退避公式计算：`lockoutDuration = baseLockout * max(tryCount / maxErrorTimes, 1)`，上限为 3 天（`MAX_LOGIN_LOCK_EXPIRE`）。
+- **手动锁定**：管理员可通过 `PUT /v1/users/{username}/lock` 立即锁定用户。脚本会向锁定键写入 `manual` 标记（无 TTL），账户将保持锁定直到被显式解锁。root 用户（`cosky`）不可被锁定。
+- **刷新令牌被拒绝**：被锁定的用户（手动标记或超过失败次数阈值）在刷新令牌时同样会被拒绝 -- 参见 [RefreshTokenAuthentication](#认证)。
+- **解锁**：管理员可通过 `DELETE /v1/users/{username}/unlock` 解锁用户，该操作会删除锁定键。
+- **可见性**：`GET /v1/users` 会为每个用户返回 `locked` 属性，当账户被手动锁定或超过失败次数阈值时为 `true`。
 
-源码: [UserService.kt:135-177](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L135)
+源码: [UserService.kt:138-180](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L138), [user_state.lua](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/resources/user_state.lua)
 
 ### 登录流程
 
@@ -90,19 +91,20 @@ sequenceDiagram
     AuthenticateController->>TokenCompositeAuth: authenticateAsToken(UserPasswordCredentials)
     TokenCompositeAuth->>UserPasswordAuth: authenticate(credentials)
     UserPasswordAuth->>UserService: login(username, pwd)
-    UserService->>Redis: INCR system:login_lock:{username}
-    Redis-->>UserService: tryCount
-    alt tryCount > 10
+    UserService->>Redis: EVAL user_state.lua (login-attempt)<br>INCR cosky-{system}:login_lock:{username}
+    Redis-->>UserService: tryCount（手动锁定时为 -1）
+    alt 手动锁定（tryCount = -1）
+        UserService-->>UserPasswordAuth: SecurityException（被管理员锁定）
+    else tryCount > 10
         UserService-->>UserPasswordAuth: SecurityException（账户已冻结）
     else 在限制内
-        UserService->>Redis: GET system:user_idx（哈希密码）
+        UserService->>Redis: HGET cosky-{system}:user_idx（哈希密码）
         Redis-->>UserService: storedHash
         alt SHA-256(pwd) != storedHash
-            UserService->>Redis: EXPIRE 锁定键（退避时长）
             UserService-->>UserPasswordAuth: SecurityException（密码错误）
         else 密码匹配
-            UserService->>Redis: DEL system:login_lock:{username}
-            UserService->>Redis: SMEMBERS system:user_role_bind:{username}
+            UserService->>Redis: EVAL user_state.lua (login-success)<br>DEL 锁定键
+            UserService->>Redis: SMEMBERS cosky-{system}:user_role_bind:{username}
             Redis-->>UserService: roleSet
             UserService-->>UserPasswordAuth: SimplePrincipal(id, roles)
         end
@@ -112,7 +114,7 @@ sequenceDiagram
     AuthenticateController-->>Client: 200 CompositeToken
 ```
 
-<!-- Sources: cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt:37, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/UserPasswordAuthentication.kt:11, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt:135 -->
+<!-- Sources: cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/AuthenticateController.kt:37, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/authentication/UserPasswordAuthentication.kt:11, cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt:139, cosky-rest-api/src/main/resources/user_state.lua:31 -->
 
 ## 授权
 
@@ -148,7 +150,7 @@ flowchart TD
 
 ### CoSkyPolicy 和 InitialPolicyLoader
 
-`CoSkyPolicy` 从 CoSky 自身的配置服务加载安全策略。策略存储在 `system` 命名空间中的配置项中。它订阅配置变更事件，并在更新时自动刷新策略缓存。
+`CoSkyPolicy` 从 CoSky 自身的配置服务加载安全策略。策略存储在 `cosky-{system}` 命名空间中的配置项中。它订阅配置变更事件，并在更新时自动刷新策略缓存。
 
 如果配置服务中不存在策略，`InitialPolicyLoader` 会从 classpath 加载内置的 `cosky-policy.json` 作为回退。
 
@@ -211,7 +213,7 @@ classDiagram
 
 ### 超级用户和管理员角色
 
-- **超级用户**：`cosky` 用户（root）绕过所有授权。当 `cosky.security.enforce-init-super-user` 为 `true` 时，由 `SecurityCommand` 在应用启动时初始化。会生成一个随机 10 字符密码并打印到标准输出。
+- **超级用户**：`cosky` 用户（root）绕过所有授权。`SecurityCommand` 在每次应用启动时都会调用 `UserService.initRoot()`；只要 root 用户不存在，就会为其生成随机 10 字符密码（打印到标准输出）。将 `cosky.security.enforce-init-super-user` 设为 `true` 会先删除已有的 root 用户，从而在每次重启时强制重置密码。
 - **管理员角色**：`admin` 角色是系统保留角色，由策略引擎的 `admin` 语句授予完全访问权限。它会自动包含在角色列表中。
 
 源码: [UserService.kt:38-52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L38), [Role.kt:31-34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/rbac/Role.kt#L31), [SecurityCommand.kt:25](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/SecurityCommand.kt#L25)
@@ -224,7 +226,7 @@ classDiagram
 
 - **operator** -- 用户名（来自安全上下文，或从登录路径提取）
 - **ip** -- 远程地址
-- **path** -- 请求 URI
+- **resource** -- 请求 URI
 - **action** -- HTTP 方法名
 - **status** -- HTTP 响应状态码
 - **msg** -- 错误消息（如有）
@@ -236,9 +238,9 @@ classDiagram
 
 ### AuditLogService
 
-`AuditLogService` 将审计日志条目以 JSON 字符串的形式持久化到 Redis List（`system:audit:log`）中。新条目推入头部（`leftPush`）。查询支持通过 `range` 进行偏移/限制分页。
+`AuditLogService` 将审计日志条目以 JSON 字符串的形式持久化到 Redis List（`cosky-{system}:audit:log`）中。新条目推入头部（`leftPush`）。查询支持通过 `range` 进行偏移/限制分页，并可通过 `GET /v1/audit-log/export` 导出为 CSV。
 
-源码: [AuditLogService.kt:27-51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogService.kt#L27)
+源码: [AuditLogService.kt:28-99](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/audit/AuditLogService.kt#L28)
 
 ## 用户管理
 
@@ -246,17 +248,19 @@ classDiagram
 
 `UserService` 完全在 Redis 中管理用户：
 
-- **用户索引**：Redis Hash（`system:user_idx`），将用户名映射到 SHA-256 密码哈希。
-- **角色绑定**：Redis Set（`system:user_role_bind:{username}`），存储分配给每个用户的角色名称。
+- **用户索引**：Redis Hash（`cosky-{system}:user_idx`），将用户名映射到 SHA-256 密码哈希。
+- **角色绑定**：Redis Set（`cosky-{system}:user_role_bind:{username}`），存储分配给每个用户的角色名称。
 - **密码哈希**：使用 Guava 的 `Hashing.sha256()` 进行 UTF-8 编码。
-- **登录锁定**：参见上方[登录锁定机制](#登录锁定机制)。
-- **Root 初始化**：`initRoot(enforce)` 使用随机密码创建或重置 `cosky` 超级用户。
+- **登录锁定**：参见上方[登录锁定机制](#登录锁定机制)。所有锁定状态变更都由 `user_state.lua` 脚本原子执行。
+- **用户列表**：`query()` 返回每个用户的角色绑定及 `locked` 属性（手动锁定或超过失败次数阈值时为 `true`）。
+- **删除保护**：root 用户（`cosky`）既不可被删除，也不可被锁定。
+- **Root 初始化**：`initRoot(enforce)` 在 root 用户不存在时创建 `cosky` 超级用户并生成随机密码；`enforce = true` 会先删除已有 root，强制重新初始化。
 
-源码: [UserService.kt:36-212](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L36)
+源码: [UserService.kt:36-288](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserService.kt#L36)
 
 ### SecurityCommand
 
-`SecurityCommand` 是一个在应用启动时运行的 `CommandLineRunner`。它调用 `UserService.initRoot()` 来初始化超级用户。当 `cosky.security.enforce-init-super-user` 设置为 `true` 时会自动执行。
+`SecurityCommand` 是一个在应用启动时运行的 `CommandLineRunner`。它无条件调用 `UserService.initRoot()`，并透传 `cosky.security.enforce-init-super-user` 标志（默认 `false`）。只要 root 用户不存在就会被创建；该标志仅控制是否先删除已有 root 并重新初始化。
 
 源码: [SecurityCommand.kt:25-34](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/SecurityCommand.kt#L25)
 
@@ -264,12 +268,13 @@ classDiagram
 
 | 方法 | 路径 | 描述 | 源码 |
 |--------|------|-------------|--------|
-| GET | `/v1/users` | 列出所有用户及其角色绑定 | [UserController.kt:42](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L42) |
-| POST | `/v1/users/{username}` | 创建新用户 | [UserController.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L52) |
-| DELETE | `/v1/users/{username}` | 移除用户 | [UserController.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L62) |
-| PATCH | `/v1/users/{username}/password` | 修改密码 | [UserController.kt:47](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L47) |
-| PATCH | `/v1/users/{username}/role` | 绑定角色到用户 | [UserController.kt:57](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L57) |
-| DELETE | `/v1/users/{username}/unlock` | 解锁被锁定的用户 | [UserController.kt:67](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L67) |
+| GET | `/v1/users` | 列出所有用户及其角色绑定与锁定状态 | [UserController.kt:44](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L44) |
+| POST | `/v1/users/{username}` | 创建新用户 | [UserController.kt:54](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L54) |
+| DELETE | `/v1/users/{username}` | 移除用户 | [UserController.kt:64](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L64) |
+| PATCH | `/v1/users/{username}/password` | 修改密码 | [UserController.kt:49](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L49) |
+| PATCH | `/v1/users/{username}/role` | 绑定角色到用户 | [UserController.kt:59](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L59) |
+| PUT | `/v1/users/{username}/lock` | 手动锁定用户（root 不可被锁定） | [UserController.kt:69](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L69) |
+| DELETE | `/v1/users/{username}/unlock` | 解锁被锁定的用户 | [UserController.kt:74](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-rest-api/src/main/kotlin/me/ahoo/cosky/rest/security/user/UserController.kt#L74) |
 
 ## 默认安全策略
 

--- a/wiki/zh/guide/service-registry.md
+++ b/wiki/zh/guide/service-registry.md
@@ -72,8 +72,8 @@ class RedisServiceRegistry(
 
 关键设计要点：
 - 临时实例被跟踪在 `ConcurrentHashMap<NamespacedInstanceId, ServiceInstance>` 中，用于心跳续约 ([RedisServiceRegistry.kt:40](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L40))。
-- `register` 方法在执行 Lua 脚本之前先将实例添加到临时映射 ([RedisServiceRegistry.kt:98](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L98))。
-- 如果续约失败（实例键不存在），会自动重新注册实例 ([RedisServiceRegistry.kt:178](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L178))。
+- `register` 方法只在 Lua 脚本执行成功后才将实例添加到临时映射——在 `doOnNext` 中，且仅当脚本返回 `true` 时 ([RedisServiceRegistry.kt:97](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L97))。
+- 如果续约失败（实例键不存在），会自动重新注册实例 ([RedisServiceRegistry.kt:184](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt#L184))。
 
 ### DiscoveryRedisScripts
 
@@ -121,7 +121,6 @@ sequenceDiagram
     participant Sub as PubSub 订阅者
 
     App->>SR: register(namespace, serviceInstance)
-    SR->>EMap: addEphemeralInstance(namespace, instance)
     SR->>SR: 构建 ARGV（ttl、serviceId、instanceId、schema、host、port、weight、metadata）
     SR->>Redis: EVAL registry_register.lua KEYS=[namespace] ARGV=[...]
     Redis->>Redis: SADD svc_itc_idx:{serviceId} {instanceId}
@@ -130,10 +129,13 @@ sequenceDiagram
     Redis->>Sub: PUBLISH svc_itc:{instanceId} "register"
     Redis->>Redis: EXPIRE svc_itc:{instanceId} {ttl}
     Redis-->>SR: Boolean (成功)
+    alt registered == true
+        SR->>EMap: addEphemeralInstance(namespace, instance)
+    end
     SR-->>App: Mono<Boolean>
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_register.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:43, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:26 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_register.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:92, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:26 -->
 
 ### 续约 / 心跳流程
 
@@ -164,7 +166,7 @@ sequenceDiagram
     end
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_renew.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewInstanceService.kt:70, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:160 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_renew.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/RenewInstanceService.kt:70, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:163 -->
 
 ### 注销流程
 
@@ -191,7 +193,7 @@ sequenceDiagram
     SR-->>App: Mono<Boolean>
 ```
 
-<!-- Sources: cosky-discovery/src/main/resources/registry_deregister.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:188, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:29 -->
+<!-- Sources: cosky-discovery/src/main/resources/registry_deregister.lua, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/RedisServiceRegistry.kt:191, cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/redis/DiscoveryRedisScripts.kt:29 -->
 
 ## Redis 键结构
 
@@ -202,9 +204,11 @@ sequenceDiagram
 | `{namespace}:svc_idx` | SET | 命名空间中所有服务 ID 的集合 | `production:svc_idx` |
 | `{namespace}:svc_stat` | HASH | 服务 ID 到实例数统计 | `production:svc_stat` |
 | `{namespace}:svc_itc_idx:{serviceId}` | SET | 指定服务的实例 ID 集合 | `production:svc_itc_idx:order-service` |
-| `{namespace}:svc_itc:{instanceId}` | HASH | 实例数据（字段：instanceId、serviceId、schema、host、port、weight、ephemeral、ttl_at、metadata） | `production:svc_itc:order-service@http#10.0.1.5#8080` |
+| `{namespace}:svc_itc:{instanceId}` | HASH | 实例数据（字段：instanceId、serviceId、schema、host、port、weight、ephemeral、metadata） | `production:svc_itc:order-service@http#10.0.1.5#8080` |
 | `{namespace}:topology_idx` | HASH | 拓扑索引：消费者名称到时间戳 | `production:topology_idx` |
 | `{namespace}:topology:{consumer}` | HASH | 拓扑依赖：生产者名称到时间戳 | `production:topology:gateway-service` |
+
+注意：`ttl_at` **并不**存储在实例哈希中。它由发现脚本在读取时按 `now + ttl` 计算得出（[discovery_get_instances.lua:33](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/discovery_get_instances.lua#L33)、[discovery_get_instance.lua:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/discovery_get_instance.lua#L30)）。续约脚本还可能向哈希中写入系统字段 `__last_renew_pub_ttl_at`，用于发布节流（[registry_renew.lua:9](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/resources/registry_renew.lua#L9)）。
 
 实例 ID 格式为 `{serviceId}@{schema}#{host}#{port}`（例如 `order-service@http#10.0.1.5#8080`），由 [`Instance.asInstanceId`](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-discovery/src/main/kotlin/me/ahoo/cosky/discovery/Instance.kt#L57) 定义。
 

--- a/wiki/zh/guide/spring-cloud-config.md
+++ b/wiki/zh/guide/spring-cloud-config.md
@@ -208,8 +208,8 @@ spring:
 
 ## 相关页面
 
-- [Spring Cloud Discovery Starter](/guide/spring-cloud-discovery) -- 基于 Redis 的服务注册与发现
-- [Configuration Center](/guide/config) -- CoSky 的配置管理 API 和 Redis 存储模型
+- [Spring Cloud Discovery Starter](/zh/guide/spring-cloud-discovery) -- 基于 Redis 的服务注册与发现
+- [Configuration Center](/zh/guide/config-service) -- CoSky 的配置管理 API 和 Redis 存储模型
 
 ## 参考
 

--- a/wiki/zh/guide/spring-cloud-discovery.md
+++ b/wiki/zh/guide/spring-cloud-discovery.md
@@ -346,9 +346,9 @@ spring:
 
 ## 相关页面
 
-- [Spring Cloud Config Starter](/guide/spring-cloud-config) -- 基于 Redis 的配置管理，支持实时刷新
-- [Service Discovery](/guide/service-discovery) -- CoSky 核心服务发现 API 和 Redis 数据模型
-- [Service Registry](/guide/service-registry) -- CoSky 的服务注册和心跳机制
+- [Spring Cloud Config Starter](/zh/guide/spring-cloud-config) -- 基于 Redis 的配置管理，支持实时刷新
+- [Service Discovery](/zh/guide/service-discovery) -- CoSky 核心服务发现 API 和 Redis 数据模型
+- [Service Registry](/zh/guide/service-registry) -- CoSky 的服务注册和心跳机制
 
 ## 参考
 

--- a/wiki/zh/guide/spring-cloud-discovery.md
+++ b/wiki/zh/guide/spring-cloud-discovery.md
@@ -94,7 +94,7 @@ CoSky 提供两种发现客户端实现，将 CoSky `ServiceDiscovery` API 适�
 
 ### 阻塞式：CoSkyDiscoveryClient
 
-[CoSkyDiscoveryClient](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt) 实现了 Spring 的 `DiscoveryClient`。它委托给响应式 `ServiceDiscovery` 并使用配置的超时时间进行阻塞（[CoSkyDiscoveryClient.kt:33](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt#L33)）。来自 CoSky 的每个 `ServiceInstance` 都被包装在 `CoSkyServiceInstance` 适配器中。
+[CoSkyDiscoveryClient](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt) 实现了 Spring 的 `DiscoveryClient`。它委托给响应式 `ServiceDiscovery` 并使用配置的超时时间进行阻塞（[CoSkyDiscoveryClient.kt:36](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryClient.kt#L36)）。来自 CoSky 的每个 `ServiceInstance` 都被包装在 `CoSkyServiceInstance` 适配器中。
 
 ### 响应式：CoSkyReactiveDiscoveryClient
 
@@ -135,7 +135,7 @@ sequenceDiagram
 
 ### CoSkyServiceRegistry
 
-[CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt) 实现了 Spring 的 `ServiceRegistry<CoSkyRegistration>` 接口。在 `register()` 时，它委托给 CoSky `ServiceRegistry` 将实例持久化到 Redis，然后启动心跳 `RenewInstanceService`（[CoSkyServiceRegistry.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L30)）。在 `deregister()` 时，它移除实例并停止心跳。`close()` 方法也会停止续期服务（[CoSkyServiceRegistry.kt:45](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L45)）。
+[CoSkyServiceRegistry](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt) 实现了 Spring 的 `ServiceRegistry<CoSkyRegistration>` 接口。在 `register()` 时，它委托给 CoSky `ServiceRegistry` 将实例持久化到 Redis，然后启动心跳 `RenewInstanceService`（[CoSkyServiceRegistry.kt:30](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L30)）。在 `deregister()` 时，它仅通过 CoSky `ServiceRegistry` 移除实例——心跳会继续运行（[CoSkyServiceRegistry.kt:38](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L38)）。续期服务由 `close()` 方法停止（[CoSkyServiceRegistry.kt:45](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyServiceRegistry.kt#L45)）。
 
 ### CoSkyRegistration
 
@@ -147,7 +147,7 @@ sequenceDiagram
 
 ### 非 Web 应用自动注册
 
-[CoSkyAutoServiceRegistrationOfNoneWeb](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt) 处理非 Web 应用程序（如 gRPC 服务、CLI 工具）。它监听 `ApplicationStartedEvent`，如果应用程序上下文不是 `WebServerApplicationContext`，则使用**进程 ID（PID）作为端口**注册服务（[CoSkyAutoServiceRegistrationOfNoneWeb.kt:51](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt#L51)）。即使没有 HTTP 端口，这也提供了一个有意义的标识符。
+[CoSkyAutoServiceRegistrationOfNoneWeb](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt) 处理非 Web 应用程序（如 gRPC 服务、CLI 工具）。它监听 `ApplicationStartedEvent`，如果应用程序上下文不是 `WebServerApplicationContext`，则使用**进程 ID（PID）作为端口**注册服务（[CoSkyAutoServiceRegistrationOfNoneWeb.kt:52](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/registry/CoSkyAutoServiceRegistrationOfNoneWeb.kt#L52)）。即使没有 HTTP 端口，这也提供了一个有意义的标识符。
 
 ### 服务注册流程
 
@@ -197,13 +197,13 @@ sequenceDiagram
 发现启动器使用 `ConsistencyRedisServiceDiscovery` 作为主要的 `ServiceDiscovery` Bean（[CoSkyDiscoveryAutoConfiguration.kt:81](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L81)）。此装饰器通过订阅以下事件，用本地一致性保证包装 `RedisServiceDiscovery`：
 
 - **ServiceEventListenerContainer** -- 监听 Redis Pub/Sub 事件，当服务被添加或移除时触发（[CoSkyDiscoveryAutoConfiguration.kt:62](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L62)）。
-- **InstanceEventListenerContainer** -- 监听 Redis Pub/Sub 事件，当单个实例发生变化（注册、注销、元数据更新）时触发（[CoSkyDiscoveryAutoConfiguration.kt:69](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L69)）。
+- **InstanceEventListenerContainer** -- 监听 Redis Pub/Sub 事件，当单个实例发生变化（注册、注销、元数据更新）时触发（[CoSkyDiscoveryAutoConfiguration.kt:71](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L71)）。
 
 这种事件驱动的方式确保本地服务缓存被及时失效和刷新，而不依赖轮询。
 
 ## 负载均衡器集成
 
-CoSky 提供了自定义的 `BinaryWeightRandomLoadBalancer`（[CoSkyDiscoveryAutoConfiguration.kt:106](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L106)），支持每实例权重。它使用在累积权重数组上的二分搜索算法，实现 O(log n) 的实例选择。负载均衡器继承 `AbstractLoadBalancer`，并在 `InstanceEventListenerContainer` 报告实例列表变更时重建其选择器。
+CoSky 提供了自定义的 `BinaryWeightRandomLoadBalancer`（[CoSkyDiscoveryAutoConfiguration.kt:109](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryAutoConfiguration.kt#L109)），支持每实例权重。它使用在累积权重数组上的二分搜索算法，实现 O(log n) 的实例选择。负载均衡器继承 `AbstractLoadBalancer`，并在 `InstanceEventListenerContainer` 报告实例列表变更时重建其选择器。
 
 ## 类图
 
@@ -347,8 +347,8 @@ spring:
 ## 相关页面
 
 - [Spring Cloud Config Starter](/guide/spring-cloud-config) -- 基于 Redis 的配置管理，支持实时刷新
-- [Service Discovery](/guide/discovery) -- CoSky 核心服务发现 API 和 Redis 数据模型
-- [Service Registry](/guide/registry) -- CoSky 的服务注册和心跳机制
+- [Service Discovery](/guide/service-discovery) -- CoSky 核心服务发现 API 和 Redis 数据模型
+- [Service Registry](/guide/service-registry) -- CoSky 的服务注册和心跳机制
 
 ## 参考
 

--- a/wiki/zh/index.md
+++ b/wiki/zh/index.md
@@ -31,7 +31,7 @@ features:
     details: 标准操作 100K+ QPS，一致性缓存层可达 70M+ QPS。基于 Redis Lua 脚本和进程内缓存。
   - title: Spring Cloud 原生集成
     icon: 🌿
-    details: 通过 Starter 开箱即用的 Spring Cloud 集成。同时支持响应式（WebClient）和阻塞式（RestClient）编程模型。
+    details: 通过 Starter 开箱即用的 Spring Cloud 集成，同时覆盖配置中心与服务发现。
   - title: 安全与 RBAC
     icon: 🔐
     details: JWT 认证、命名空间级别的 RBAC 权限控制、审计日志和基于 CoSec 的策略授权。


### PR DESCRIPTION
## Summary

A full audit of every wiki page (English + Chinese) against the current source code. The wiki was generated before the 5.6.0–5.7.2 releases and the dashboard rewrite (#958, #959, #961), so a number of pages had drifted from reality — including installation instructions that could not work at all. Every fix was verified against the code; all pages were updated in both languages in sync.

## Changes

**Critical (copy-paste instructions were broken):**
- Starter coordinates corrected to `me.ahoo.cosky:cosky-spring-cloud-starter-config` / `cosky-spring-cloud-starter-discovery` — the legacy `spring-cloud-starter-cosky-*` artifacts stop at 3.3.14 on Maven Central, while the current line publishes under the new names (verified on Maven Central, latest 5.7.2). Version management now uses `cosky-bom` instead of `cosky-dependencies` (which constrains only external dependencies). Also fixed in `README.md`.
- Standalone install instructions no longer reference `cosky-server.tar` — GitHub releases publish no assets, so the `wget` always 404'd. Docs now build from source via `./gradlew :cosky-rest-api:distTar`, run `bin/cosky-rest-api` (not `bin/cosky`), and reflect the real distribution layout (`ui/`, `static-locations: file:./ui/`).

**Dashboard page rewritten for the new stack (#958):**
- Ant Design 6 → Radix UI + shadcn/ui (Tailwind CSS 4), `fetcher-viewer` removed, `fetcher-storage`/`fetcher-decorator` added, Playwright testing documented.
- New features documented: keyboard navigation search (#961), user lock/unlock with `locked` badge (#959), audit-log CSV export.

**Security & RBAC page updated for the lockout hardening (#959):**
- New `PUT /v1/users/{username}/lock` endpoint documented (root user cannot be locked).
- Lockout mechanics rewritten for the atomic `user_state.lua` script (operations `login-attempt`/`login-success`/`lock`/`remove`), including the `manual` marker semantics and locked users being rejected on token refresh via `ensureUnlocked`.
- System Redis keys corrected to the real `cosky-{system}:*` prefix; audit field `path` → `resource`; super-user initialization semantics corrected (`initRoot` runs unconditionally; `enforce-init-super-user` only forces re-init).

**Config consistency page corrected:**
- The initial cache entry is created with plain `.cache()` (no TTL) — a missed first PubSub event means indefinite staleness, not "self-heals within 60 s" as previously claimed. The 1-minute `CONFIG_CACHE_TTL` applies only to entries refreshed by an invalidation event.
- Invalidation flow diagram corrected: lazy overwrite with a cold `Mono`, no eager remove + re-fetch; event type (set/remove/rollback) is never inspected. State machine redrawn to match.

**Discovery pages corrected:**
- Register flow: ephemeral map is updated *after* the Lua script succeeds (`doOnNext`), not before — prose and sequence diagram fixed.
- Removed phantom `ttl_at` hash field (computed at read time by the discovery Lua scripts).
- `deregister()` no longer claims to stop the heartbeat (only `close()` does); broken links `/guide/discovery` and `/guide/registry` fixed; Kotlin snippet parameter corrected to `serviceInstance = instance`.

**REST API page:** added `GET /v1/audit-log/export` (CSV) and the user-lock endpoint; repaired stale line citations; made the quoted `application.yaml` excerpt faithful to the real file.

**Misc:** architecture page Gradle 8.x → 9.x; guide index dropped the unsupported "last 10 versions" claim (history is unbounded); homepage removed the fabricated "WebClient and RestClient" claim; k8s pages now reproduce the in-repo manifests verbatim and note they pin the 5.3.5 image tag.

**Build fix (wiki):** pnpm 11 ignores `package.json#pnpm` — the security overrides (dompurify, js-yaml, introduced in d22fd91f) had been silently dropped from `pnpm-lock.yaml`. Overrides moved to `wiki/pnpm-workspace.yaml` (supported by both pnpm 10 in CI and 11 locally), and the `allowBuilds` placeholder for puppeteer fixed.

## Testing

- [x] `pnpm validate:mermaid` — 52 files scanned, 0 issues
- [x] `pnpm build` — VitePress production build succeeds
- [x] Every corrected claim cross-checked against source (file:line evidence); critical coordinates additionally verified on Maven Central and the GitHub releases API

## Notes

- Screenshots under `wiki/public/` still show the pre-rewrite (Ant Design) dashboard UI; re-capturing them needs a running Redis + REST API stack and is left for a follow-up.
- The in-repo k8s manifests (`k8s/deployment/*.yml`) themselves still pin image tag `5.3.5` — the docs now call this out, but the manifests may deserve a separate bump.
