### PR TITLE
feat(dashboard): polish sidebar, config differ, command palette, and forms

### DIFF
--- a/dashboard/src/components/layout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout.tsx
@@ -72,6 +72,11 @@ const securityItems = [
 
 const searchTargets = [...primaryItems, ...securityItems];
 
+// Radix sheets/dialogs expose explicit roles; the topology fullscreen uses a native
+// <dialog> whose implicit role carries no attribute, hence the dialog[open] check.
+const isModalOpen = () =>
+    Boolean(document.querySelector('[role="dialog"], [role="alertdialog"], dialog[open]'));
+
 export const AuthenticatedLayout = () => {
     const [collapsed, setCollapsed] = useLayoutCollapsed();
     const [searchValue, setSearchValue] = useState('');
@@ -96,7 +101,7 @@ export const AuthenticatedLayout = () => {
             const isCommandK = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k';
             if (!isCommandK && event.key !== '/') return;
             // Never hijack keys while a modal surface (sheet, dialog, alert dialog) is open.
-            if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return;
+            if (isModalOpen()) return;
             // '/' stays out of the way of typing; Ctrl/Cmd+K intentionally works from anywhere.
             if (!isCommandK && event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
             event.preventDefault();
@@ -164,6 +169,7 @@ export const AuthenticatedLayout = () => {
 
     const handleLayoutKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
         if (event.key !== '/') return;
+        if (isModalOpen()) return;
         if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
         event.preventDefault();
         event.stopPropagation();

--- a/dashboard/src/components/layout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout.tsx
@@ -100,6 +100,8 @@ export const AuthenticatedLayout = () => {
         const focusSearch = (event: globalThis.KeyboardEvent) => {
             const isCommandK = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k';
             if (!isCommandK && event.key !== '/') return;
+            // The search control is display:none below 720px — leave the shortcuts alone there.
+            if (searchInputRef.current?.checkVisibility() !== true) return;
             // Never hijack keys while a modal surface (sheet, dialog, alert dialog) is open.
             if (isModalOpen()) return;
             // '/' stays out of the way of typing; Ctrl/Cmd+K intentionally works from anywhere.
@@ -169,6 +171,7 @@ export const AuthenticatedLayout = () => {
 
     const handleLayoutKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
         if (event.key !== '/') return;
+        if (searchInputRef.current?.checkVisibility() !== true) return;
         if (isModalOpen()) return;
         if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
         event.preventDefault();

--- a/dashboard/src/components/layout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout.tsx
@@ -20,6 +20,7 @@ import {
     ChevronsRight,
     Cloud,
     FileText,
+    History,
     LayoutDashboard,
     LogOut,
     Menu,
@@ -28,6 +29,7 @@ import {
     PanelLeftOpen,
     Search,
     Settings,
+    Shield,
     ShieldCheck,
     User,
     X,
@@ -65,7 +67,7 @@ const primaryItems = [
 const securityItems = [
     {to: '/user', label: 'User', description: 'Accounts and role assignments', icon: User},
     {to: '/role', label: 'Role', description: 'Access policies', icon: ShieldCheck},
-    {to: '/audit-log', label: 'Audit Log', description: 'Security and operation history', icon: FileText},
+    {to: '/audit-log', label: 'Audit Log', description: 'Security and operation history', icon: History},
 ];
 
 const searchTargets = [...primaryItems, ...securityItems];
@@ -91,8 +93,12 @@ export const AuthenticatedLayout = () => {
 
     useEffect(() => {
         const focusSearch = (event: globalThis.KeyboardEvent) => {
-            if (event.key !== '/') return;
-            if (event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
+            const isCommandK = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k';
+            if (!isCommandK && event.key !== '/') return;
+            // Never hijack keys while a modal surface (sheet, dialog, alert dialog) is open.
+            if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return;
+            // '/' stays out of the way of typing; Ctrl/Cmd+K intentionally works from anywhere.
+            if (!isCommandK && event.target instanceof HTMLElement && event.target !== searchInputRef.current && event.target.matches('input, textarea, select, [contenteditable="true"]')) return;
             event.preventDefault();
             searchInputRef.current?.focus();
             setSearchOpen(true);
@@ -135,7 +141,9 @@ export const AuthenticatedLayout = () => {
             return;
         }
         if (event.key === 'Escape') {
+            setSearchValue('');
             setSearchOpen(false);
+            event.currentTarget.blur();
             return;
         }
         if (!['ArrowDown', 'ArrowUp'].includes(event.key) || filteredSearchTargets.length === 0) return;
@@ -182,14 +190,14 @@ export const AuthenticatedLayout = () => {
                             {!collapsed && <span>{label}</span>}
                         </NavLink>
                     ))}
-                    <Collapsible defaultOpen={securityItems.some(item => item.to === location.pathname)}>
-                        <CollapsibleTrigger asChild>
-                            <button type="button" className="app-nav-item app-nav-group" title="Security">
-                                <ShieldCheck/>
-                                {!collapsed && <><span>Security</span><ChevronDown className="app-nav-chevron"/></>}
-                            </button>
-                        </CollapsibleTrigger>
-                        {!collapsed && (
+                    {!collapsed ? (
+                        <Collapsible defaultOpen={securityItems.some(item => item.to === location.pathname)}>
+                            <CollapsibleTrigger asChild>
+                                <button type="button" className="app-nav-item app-nav-group" title="Security">
+                                    <Shield/>
+                                    <span>Security</span><ChevronDown className="app-nav-chevron"/>
+                                </button>
+                            </CollapsibleTrigger>
                             <CollapsibleContent className="app-nav-submenu">
                                 {securityItems.map(({to, label, icon: Icon}) => (
                                     <NavLink key={to} to={to} onClick={() => setMobileOpen(false)} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
@@ -198,9 +206,8 @@ export const AuthenticatedLayout = () => {
                                     </NavLink>
                                 ))}
                             </CollapsibleContent>
-                        )}
-                    </Collapsible>
-                    {collapsed && securityItems.map(({to, label, icon: Icon}) => (
+                        </Collapsible>
+                    ) : securityItems.map(({to, label, icon: Icon}) => (
                         <NavLink key={to} to={to} title={label} onClick={() => setMobileOpen(false)} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
                             <Icon/>
                         </NavLink>

--- a/dashboard/src/components/topology/Topology.tsx
+++ b/dashboard/src/components/topology/Topology.tsx
@@ -200,6 +200,7 @@ export function Topology() {
                     <Background/>
                     <Controls/>
                     <MiniMap
+                        className="max-sm:hidden"
                         position="top-right"
                         nodeColor={(node) => {
                             if (isServiceNodeData(node.data)) {

--- a/dashboard/src/components/ui/definition-list.tsx
+++ b/dashboard/src/components/ui/definition-list.tsx
@@ -24,7 +24,7 @@ export function DefinitionList({items}: {items: DefinitionItem[]}) {
             {items.map((item) => (
                 <div key={item.label} className="grid grid-cols-[9rem_1fr] border-b px-4 py-3 last:border-b-0 sm:even:border-l">
                     <dt className="text-sm text-muted-foreground">{item.label}</dt>
-                    <dd className="break-words text-sm font-medium text-foreground">{item.value}</dd>
+                    <dd className="min-w-0 break-words text-sm font-medium text-foreground">{item.value}</dd>
                 </div>
             ))}
         </dl>

--- a/dashboard/src/components/ui/definition-list.tsx
+++ b/dashboard/src/components/ui/definition-list.tsx
@@ -24,7 +24,7 @@ export function DefinitionList({items}: {items: DefinitionItem[]}) {
             {items.map((item) => (
                 <div key={item.label} className="grid grid-cols-[9rem_1fr] border-b px-4 py-3 last:border-b-0 sm:even:border-l">
                     <dt className="text-sm text-muted-foreground">{item.label}</dt>
-                    <dd className="break-all text-sm font-medium text-foreground">{item.value}</dd>
+                    <dd className="break-words text-sm font-medium text-foreground">{item.value}</dd>
                 </div>
             ))}
         </dl>

--- a/dashboard/src/pages/audit/AuditLogPage.tsx
+++ b/dashboard/src/pages/audit/AuditLogPage.tsx
@@ -58,7 +58,7 @@ const toSuccessful = (status: AuditStatus) => status === 'all' ? undefined : sta
 
 function AuditLogDetails({log}: {log: AuditLog}) {
     return <DefinitionList items={[
-        {label: 'Timestamp', value: dayjs(log.opTime).format('YYYY-MM-DD HH:mm:ss.SSS')},
+        {label: 'Timestamp', value: dayjs(log.opTime).format('YYYY-MM-DD HH:mm:ss')},
         {label: 'Operator', value: log.operator},
         {label: 'Client IP', value: log.ip},
         {label: 'Resource', value: <code>{log.resource}</code>},

--- a/dashboard/src/pages/config/ConfigVersionDiffer.tsx
+++ b/dashboard/src/pages/config/ConfigVersionDiffer.tsx
@@ -6,6 +6,7 @@ import {getFileNameWithExt} from "./fileNames.ts";
 import dayjs from "dayjs";
 import {toast} from 'sonner';
 import {ConfirmButton} from '@/components/ui/confirm-button';
+import {Badge} from '@/components/ui/badge';
 import {DefinitionList} from '@/components/ui/definition-list';
 import {Separator} from '@/components/ui/separator';
 import {Skeleton} from '@/components/ui/skeleton';
@@ -45,6 +46,7 @@ export function ConfigVersionDiffer({namespace, configId, version, onSuccess}: C
             return configApiClient.rollback(namespace, configId, version)
         });
     }
+    const isCurrent = versionConfig?.version !== undefined && versionConfig.version === currentConfig?.version;
     const fileNameWithExt = getFileNameWithExt(configId);
     if (currentLoading || versionLoading) {
         return (
@@ -56,7 +58,15 @@ export function ConfigVersionDiffer({namespace, configId, version, onSuccess}: C
             <DefinitionList items={[
                 {label: 'File Name', value: configId},
                 {label: 'Hash', value: versionConfig?.hash},
-                {label: 'History Version', value: versionConfig?.version},
+                {
+                    label: 'History Version',
+                    value: (
+                        <span className="inline-flex items-center gap-2">
+                            {versionConfig?.version}
+                            {isCurrent && <Badge variant="secondary">Current</Badge>}
+                        </span>
+                    ),
+                },
                 {label: 'Operation', value: versionConfig?.op},
                 {label: 'Create Time', value: dayjs((versionConfig?.createTime ?? 0) * 1000).format('YYYY-MM-DD HH:mm:ss')},
                 {label: 'Operation Time', value: dayjs((versionConfig?.opTime ?? 0) * 1000).format('YYYY-MM-DD HH:mm:ss')},
@@ -78,10 +88,14 @@ export function ConfigVersionDiffer({namespace, configId, version, onSuccess}: C
                 }}
             />
             <Separator/>
+            {isCurrent && (
+                <p className="text-center text-xs text-muted-foreground">This version is currently active — there is nothing to roll back.</p>
+            )}
             <ConfirmButton title="Rollback to this version?"
                         description={`Configuration “${configId}” will change from version ${currentConfig?.version} to history version ${version}. A new audit event will be recorded.`}
                         onConfirm={handleRollback}
                         loading={rollbackLoading}
+                        disabled={isCurrent}
                         className="w-full"
             >
                 Rollback to version {version}

--- a/dashboard/src/pages/config/ConfigVersionDiffer.tsx
+++ b/dashboard/src/pages/config/ConfigVersionDiffer.tsx
@@ -6,7 +6,6 @@ import {getFileNameWithExt} from "./fileNames.ts";
 import dayjs from "dayjs";
 import {toast} from 'sonner';
 import {ConfirmButton} from '@/components/ui/confirm-button';
-import {Badge} from '@/components/ui/badge';
 import {DefinitionList} from '@/components/ui/definition-list';
 import {Separator} from '@/components/ui/separator';
 import {Skeleton} from '@/components/ui/skeleton';
@@ -46,7 +45,6 @@ export function ConfigVersionDiffer({namespace, configId, version, onSuccess}: C
             return configApiClient.rollback(namespace, configId, version)
         });
     }
-    const isCurrent = versionConfig?.version !== undefined && versionConfig.version === currentConfig?.version;
     const fileNameWithExt = getFileNameWithExt(configId);
     if (currentLoading || versionLoading) {
         return (
@@ -58,15 +56,7 @@ export function ConfigVersionDiffer({namespace, configId, version, onSuccess}: C
             <DefinitionList items={[
                 {label: 'File Name', value: configId},
                 {label: 'Hash', value: versionConfig?.hash},
-                {
-                    label: 'History Version',
-                    value: (
-                        <span className="inline-flex items-center gap-2">
-                            {versionConfig?.version}
-                            {isCurrent && <Badge variant="secondary">Current</Badge>}
-                        </span>
-                    ),
-                },
+                {label: 'History Version', value: versionConfig?.version},
                 {label: 'Operation', value: versionConfig?.op},
                 {label: 'Create Time', value: dayjs((versionConfig?.createTime ?? 0) * 1000).format('YYYY-MM-DD HH:mm:ss')},
                 {label: 'Operation Time', value: dayjs((versionConfig?.opTime ?? 0) * 1000).format('YYYY-MM-DD HH:mm:ss')},
@@ -88,14 +78,10 @@ export function ConfigVersionDiffer({namespace, configId, version, onSuccess}: C
                 }}
             />
             <Separator/>
-            {isCurrent && (
-                <p className="text-center text-xs text-muted-foreground">This version is currently active — there is nothing to roll back.</p>
-            )}
             <ConfirmButton title="Rollback to this version?"
                         description={`Configuration “${configId}” will change from version ${currentConfig?.version} to history version ${version}. A new audit event will be recorded.`}
                         onConfirm={handleRollback}
                         loading={rollbackLoading}
-                        disabled={isCurrent}
                         className="w-full"
             >
                 Rollback to version {version}

--- a/dashboard/src/pages/service/SchemaSelectorOptions.ts
+++ b/dashboard/src/pages/service/SchemaSelectorOptions.ts
@@ -1,10 +1,10 @@
 export const SCHEMA_SELECTOR_OPTIONS = [
     {
-        label: 'Http',
+        label: 'HTTP',
         value: 'http'
     },
     {
-        label: 'Https',
+        label: 'HTTPS',
         value: 'https'
     }
 ]

--- a/dashboard/src/pages/service/ServiceInstanceEditor.tsx
+++ b/dashboard/src/pages/service/ServiceInstanceEditor.tsx
@@ -84,16 +84,16 @@ export function ServiceInstanceEditor({
         <form className="space-y-5" onSubmit={handleFinish}>
             <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                    <Label>Schema</Label>
-                    <SchemaSelector value={schema} onChange={setSchema} disabled={!!initialValues}/>
+                    <Label>Scheme</Label>
+                    <SchemaSelector value={schema} onChange={setSchema} disabled={!!initialValues} ariaLabel="Scheme"/>
                 </div>
                 <div className="space-y-2">
                     <Label htmlFor="instance-host">Host</Label>
-                    <Input id="instance-host" name="host" defaultValue={initialValues?.host} disabled={!!initialValues} required/>
+                    <Input id="instance-host" name="host" placeholder="192.168.0.10 or api.internal" defaultValue={initialValues?.host} disabled={!!initialValues} required/>
                 </div>
                 <div className="space-y-2">
                     <Label htmlFor="instance-port">Port</Label>
-                    <Input id="instance-port" name="port" type="number" min={1} max={65535} defaultValue={initialValues?.port} disabled={!!initialValues} required/>
+                    <Input id="instance-port" name="port" type="number" min={1} max={65535} placeholder="8080" defaultValue={initialValues?.port} disabled={!!initialValues} required/>
                 </div>
                 <div className="space-y-2">
                     <Label htmlFor="instance-weight">Weight</Label>

--- a/dashboard/src/pages/service/ServiceInstanceTable.tsx
+++ b/dashboard/src/pages/service/ServiceInstanceTable.tsx
@@ -73,7 +73,7 @@ export function ServiceInstanceTable({namespace, serviceId}: ServiceInstanceTabl
                 return <Badge variant={health === 'Healthy' ? 'secondary' : health === 'Expiring soon' ? 'outline' : 'destructive'}>{health}</Badge>;
             },
         },
-        {header: 'Schema', accessor: 'schema', key: 'schema'},
+        {header: 'Scheme', accessor: 'schema', key: 'schema'},
         {
             header: 'Host', accessor: 'host', key: 'host',
             sort: (left, right) => left.host.localeCompare(right.host),

--- a/dashboard/tests/ui/dashboard.spec.ts
+++ b/dashboard/tests/ui/dashboard.spec.ts
@@ -116,12 +116,12 @@ test('configuration workflow covers search, history, editor, and import', async 
     await search.clear();
 
     await page.getByRole('button', {name: 'Expand row'}).first().click();
-    await expect(page.getByRole('cell', {name: '3', exact: true})).toBeVisible();
+    await expect(page.getByRole('cell', {name: '2', exact: true})).toBeVisible();
     await expect(page.getByRole('cell', {name: 'UPDATE', exact: true}).first()).toBeVisible();
-    await expect(page.getByRole('cell', {name: '8f4a21c', exact: true}).first()).toBeVisible();
+    await expect(page.getByRole('cell', {name: '8f4a21c9e3b7', exact: true}).first()).toBeVisible();
     await page.getByRole('button', {name: 'Diff', exact: true}).first().click();
     await expect(page.getByRole('dialog', {name: 'Config Version Differ'})).toBeVisible();
-    await expect(page.getByRole('button', {name: 'Rollback to version 3'})).toBeVisible();
+    await expect(page.getByRole('button', {name: 'Rollback to version 2'})).toBeVisible();
     await page.getByRole('button', {name: 'Close', exact: true}).click();
 
     await page.getByRole('button', {name: 'Add', exact: true}).click();
@@ -281,7 +281,7 @@ test('remaining mutations cover edit, export, rollback, delete, password, and si
     await expect(page.getByText('Export config success')).toBeVisible();
 
     await page.getByRole('button', {name: 'Expand row'}).first().click();
-    await page.getByRole('button', {name: 'Diff', exact: true}).nth(1).click();
+    await page.getByRole('button', {name: 'Diff', exact: true}).first().click();
     await page.getByRole('button', {name: 'Rollback to version 2'}).click();
     await page.getByRole('button', {name: 'Continue'}).click();
     await expect(page.getByText('Rollback success')).toBeVisible();

--- a/dashboard/tests/ui/dashboard.spec.ts
+++ b/dashboard/tests/ui/dashboard.spec.ts
@@ -281,8 +281,8 @@ test('remaining mutations cover edit, export, rollback, delete, password, and si
     await expect(page.getByText('Export config success')).toBeVisible();
 
     await page.getByRole('button', {name: 'Expand row'}).first().click();
-    await page.getByRole('button', {name: 'Diff', exact: true}).first().click();
-    await page.getByRole('button', {name: 'Rollback to version 3'}).click();
+    await page.getByRole('button', {name: 'Diff', exact: true}).nth(1).click();
+    await page.getByRole('button', {name: 'Rollback to version 2'}).click();
     await page.getByRole('button', {name: 'Continue'}).click();
     await expect(page.getByText('Rollback success')).toBeVisible();
 
@@ -369,7 +369,7 @@ test('remaining mutations cover edit, export, rollback, delete, password, and si
     for (const [method, path] of [
         ['PATCH', '/v1/users/admin/password'],
         ['GET', '/configs/export'],
-        ['PUT', '/to/3'],
+        ['PUT', '/to/2'],
         ['DELETE', '/configs/application.yaml'],
         ['PUT', '/services/qa-service'],
         ['DELETE', '/instances/api-gateway-01'],

--- a/dashboard/tests/ui/mock-api.ts
+++ b/dashboard/tests/ui/mock-api.ts
@@ -15,6 +15,8 @@ import type {Page, Route} from '@playwright/test';
 
 const now = Date.UTC(2026, 7, 18, 1, 0, 0);
 const tokenNow = Math.floor(Date.now() / 1000);
+// Realistic 64-char SHA-256 style hash, used wherever the mock serves config hashes.
+const CONFIG_HASH = '8f4a21c9e3b74d5f8a2c1e9b3d74f5a8c2e9b3d74f5a8c2e9b3d74f5a8c2e9b3';
 const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64url');
 const token = `${encode({alg: 'none', typ: 'JWT'})}.${encode({
     sub: 'admin',
@@ -239,7 +241,7 @@ export async function installApiMock(page: Page) {
             const configId = decodeURIComponent(pathname.split('/').at(-3)!);
             await json(route, {
                 configId,
-                hash: '8f4a21c',
+                hash: CONFIG_HASH,
                 version: Number(pathname.split('/').at(-1)),
                 data: 'server:\n  port: 8080\nfeature:\n  enabled: true',
                 createTime: Math.floor(now / 1000) - 7200,
@@ -249,9 +251,10 @@ export async function installApiMock(page: Page) {
             return;
         }
         if (/\/configs\/[^/]+\/versions$/.test(pathname)) {
+            // Mirrors the real backend: the history index only contains superseded
+            // versions, never the current one (current is 3, see the config GET below).
             await json(route, [
-                {version: 3, hash: '8f4a21c', createTime: Math.floor(now / 1000) - 3600},
-                {version: 2, hash: '7d2a11b', createTime: Math.floor(now / 1000) - 7200},
+                {version: 2, hash: CONFIG_HASH, createTime: Math.floor(now / 1000) - 7200},
                 {version: 1, hash: '6c1f09a', createTime: Math.floor(now / 1000) - 10_800},
             ]);
             return;
@@ -260,7 +263,7 @@ export async function installApiMock(page: Page) {
             const configId = decodeURIComponent(pathname.split('/').at(-1)!);
             await json(route, {
                 configId,
-                hash: '8f4a21c',
+                hash: 'd3b2a1c',
                 version: 3,
                 data: 'server:\n  port: 8080\nfeature:\n  enabled: true',
                 createTime: Math.floor(now / 1000) - 3600,

--- a/dashboard/tests/ui/ux-polish.spec.ts
+++ b/dashboard/tests/ui/ux-polish.spec.ts
@@ -34,25 +34,49 @@ test('collapsed sidebar drops the inert Security group toggle and keeps icons di
     expect(await iconOf('Configuration')).not.toBe(await iconOf('Audit Log'));
 });
 
-test('config differ marks the current version and blocks a no-op rollback', async ({page}) => {
+test('definition list wraps long unbroken values instead of clipping them', async ({page}) => {
     await login(page);
     await page.getByRole('link', {name: 'Configuration', exact: true}).click();
     await page.getByRole('button', {name: 'Expand row'}).first().click();
+    await page.getByRole('table').nth(1).getByRole('button', {name: 'Diff', exact: true}).first().click();
 
-    const versionTable = page.getByRole('table').nth(1);
-    const diffButtons = versionTable.getByRole('button', {name: 'Diff', exact: true});
-
-    // First data row is version 3, which the mocked current config also reports as its version.
-    await diffButtons.first().click();
     const differ = page.getByRole('dialog', {name: 'Config Version Differ'});
-    await expect(differ.getByText('Current', {exact: true})).toBeVisible();
-    await expect(differ.getByRole('button', {name: 'Rollback to version 3'})).toBeDisabled();
-    await page.getByRole('button', {name: 'Close', exact: true}).click();
+    // The mock serves a realistic 64-char hash — a single unbroken word that must
+    // wrap within the definition cell instead of overflowing the overflow-hidden list.
+    const hashCell = differ.getByText(/^[0-9a-f]{64}$/);
+    const metrics = await hashCell.evaluate(element => {
+        const cellRect = element.getBoundingClientRect();
+        const listRect = element.closest('dl')!.getBoundingClientRect();
+        return {cellRight: cellRect.right, listRight: listRect.right};
+    });
+    expect(metrics.cellRight).toBeLessThanOrEqual(metrics.listRight + 1);
+});
 
-    // Older versions still offer rollback.
-    await diffButtons.nth(1).click();
-    await expect(differ.getByRole('button', {name: 'Rollback to version 2'})).toBeEnabled();
-    await expect(differ.getByText('Current', {exact: true})).toBeHidden();
+test('command palette shortcuts stay inert inside the native topology dialog', async ({page}) => {
+    await login(page);
+    const search = page.getByRole('combobox', {name: 'Search navigation'});
+    await expect(search).toBeVisible();
+
+    await page.getByRole('button', {name: 'Open topology fullscreen'}).click();
+    const dialog = page.getByRole('dialog', {name: 'Service Topology'});
+    await expect(dialog).toBeVisible();
+
+    const paletteState = () => page.evaluate(() => {
+        const searchInput = document.querySelector('input[aria-label="Search navigation"]');
+        return {
+            ariaExpanded: searchInput?.getAttribute('aria-expanded'),
+            searchFocused: document.activeElement === searchInput,
+        };
+    });
+
+    // Focus a non-input control inside the native <dialog>, then try both shortcuts.
+    await page.getByRole('button', {name: 'Close topology fullscreen'}).focus();
+    await page.keyboard.press('/');
+    await page.keyboard.press('Control+k');
+
+    const state = await paletteState();
+    expect(state.ariaExpanded).toBe('false');
+    expect(state.searchFocused).toBe(false);
 });
 
 test('command palette shortcuts do not steal focus from open dialogs', async ({page}) => {

--- a/dashboard/tests/ui/ux-polish.spec.ts
+++ b/dashboard/tests/ui/ux-polish.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect, test} from './coverage';
+import {installApiMock, login} from './mock-api';
+
+test.beforeEach(async ({page}) => {
+    await installApiMock(page);
+});
+
+test('collapsed sidebar drops the inert Security group toggle and keeps icons distinguishable', async ({page}) => {
+    await login(page);
+    await page.getByRole('button', {name: 'Collapse navigation'}).click();
+
+    // The Security collapsible renders no content when collapsed — its trigger must not stay behind as a dead button.
+    await expect(page.getByRole('button', {name: 'Security', exact: true})).toHaveCount(0);
+    await expect(page.getByRole('link', {name: 'User', exact: true})).toBeVisible();
+    await expect(page.getByRole('link', {name: 'Role', exact: true})).toBeVisible();
+    await expect(page.getByRole('link', {name: 'Audit Log', exact: true})).toBeVisible();
+
+    // Configuration/Audit Log and Security/Role must not share identical icons in the icon-only rail.
+    const iconOf = (name: string) =>
+        page.getByRole('link', {name, exact: true}).locator('svg').first().evaluate(element => element.innerHTML);
+    expect(await iconOf('Configuration')).not.toBe(await iconOf('Audit Log'));
+});
+
+test('config differ marks the current version and blocks a no-op rollback', async ({page}) => {
+    await login(page);
+    await page.getByRole('link', {name: 'Configuration', exact: true}).click();
+    await page.getByRole('button', {name: 'Expand row'}).first().click();
+
+    const versionTable = page.getByRole('table').nth(1);
+    const diffButtons = versionTable.getByRole('button', {name: 'Diff', exact: true});
+
+    // First data row is version 3, which the mocked current config also reports as its version.
+    await diffButtons.first().click();
+    const differ = page.getByRole('dialog', {name: 'Config Version Differ'});
+    await expect(differ.getByText('Current', {exact: true})).toBeVisible();
+    await expect(differ.getByRole('button', {name: 'Rollback to version 3'})).toBeDisabled();
+    await page.getByRole('button', {name: 'Close', exact: true}).click();
+
+    // Older versions still offer rollback.
+    await diffButtons.nth(1).click();
+    await expect(differ.getByRole('button', {name: 'Rollback to version 2'})).toBeEnabled();
+    await expect(differ.getByText('Current', {exact: true})).toBeHidden();
+});
+
+test('command palette shortcuts do not steal focus from open dialogs', async ({page}) => {
+    await login(page);
+    const search = page.getByRole('combobox', {name: 'Search navigation'});
+    await expect(search).toBeVisible();
+
+    await page.getByRole('link', {name: 'Configuration', exact: true}).click();
+    await page.getByRole('button', {name: 'Add', exact: true}).click();
+    const dialog = page.getByRole('dialog', {name: 'Add Config'});
+    await expect(dialog).toBeVisible();
+
+    // Elements outside an open dialog are aria-hidden, so assert via DOM attributes instead of role locators.
+    const paletteState = () => page.evaluate(() => {
+        const searchInput = document.querySelector('input[aria-label="Search navigation"]');
+        return {
+            ariaExpanded: searchInput?.getAttribute('aria-expanded'),
+            searchFocused: document.activeElement === searchInput,
+            activeElementId: document.activeElement?.id ?? null,
+        };
+    });
+
+    // Ctrl+K while typing in a dialog field must not move focus to the header search.
+    await page.locator('#config-file-name').click();
+    await page.keyboard.press('Control+k');
+    let state = await paletteState();
+    expect(state.searchFocused).toBe(false);
+    expect(state.ariaExpanded).toBe('false');
+    expect(state.activeElementId).toBe('config-file-name');
+
+    // '/' with focus on a non-input control inside a dialog must not open the palette behind the modal.
+    const closeButton = dialog.getByRole('button', {name: 'Close', exact: true});
+    await closeButton.focus();
+    await page.keyboard.press('/');
+    state = await paletteState();
+    expect(state.ariaExpanded).toBe('false');
+    expect(await closeButton.evaluate(element => document.activeElement === element)).toBe(true);
+});
+
+test('audit event details keep the timestamp on a single line', async ({page}) => {
+    await login(page);
+    await page.getByRole('button', {name: 'Security', exact: true}).click();
+    await page.getByRole('link', {name: 'Audit Log', exact: true}).click();
+    await page.getByRole('button', {name: 'Details'}).first().click();
+
+    const dialog = page.getByRole('dialog', {name: 'Audit Event Details'});
+    // Seconds precision matches the audit table and always fits the details cell on one line.
+    const timestamp = dialog.getByText(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    const metrics = await timestamp.evaluate(element => {
+        const style = getComputedStyle(element);
+        return {
+            wordBreak: style.wordBreak,
+            height: element.getBoundingClientRect().height,
+            lineHeight: parseFloat(style.lineHeight),
+        };
+    });
+    expect(metrics.wordBreak).not.toBe('break-all');
+    expect(metrics.height).toBeLessThanOrEqual(metrics.lineHeight + 2);
+});
+
+test('topology hides the minimap on small screens', async ({page}) => {
+    await login(page);
+    await expect(page.locator('.react-flow__minimap')).toBeVisible();
+    await page.setViewportSize({width: 390, height: 844});
+    await expect(page.locator('.react-flow__minimap')).toBeHidden();
+});
+
+test('command palette supports Ctrl+K and Escape clears the query', async ({page}) => {
+    await login(page);
+    const search = page.getByRole('combobox', {name: 'Search navigation'});
+    // Let the layout effects settle before relying on the global shortcut listener.
+    await expect(search).toBeVisible();
+
+    await page.keyboard.press('Control+k');
+    await expect(search).toBeFocused();
+    await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeVisible();
+
+    await search.fill('serv');
+    await search.press('Escape');
+    await expect(page.getByRole('listbox', {name: 'Navigation results'})).toBeHidden();
+    await expect(search).toHaveValue('');
+
+    // Reopening starts from a clean slate instead of the stale query.
+    await page.keyboard.press('/');
+    await expect(search).toBeFocused();
+    await expect(search).toHaveValue('');
+});
+
+test('service views use scheme naming, HTTP option labels, and input placeholders', async ({page}) => {
+    await login(page);
+    await page.getByRole('link', {name: 'Service', exact: true}).click();
+
+    await page.getByRole('button', {name: 'Expand row'}).first().click();
+    const instanceTable = page.getByRole('table').nth(1);
+    await expect(instanceTable.getByRole('columnheader', {name: 'Scheme', exact: true})).toBeVisible();
+
+    await page.getByRole('button', {name: 'Add instance', exact: true}).first().click();
+    const dialog = page.getByRole('dialog', {name: 'Add [api-gateway] Instance'});
+    await dialog.getByRole('combobox', {name: 'Scheme'}).click();
+    await expect(page.getByRole('option', {name: 'HTTP', exact: true})).toBeVisible();
+    await expect(page.getByRole('option', {name: 'HTTPS', exact: true})).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    await expect(dialog.getByRole('textbox', {name: 'Host'})).toHaveAttribute('placeholder', /./);
+    await expect(dialog.getByRole('spinbutton', {name: 'Port'})).toHaveAttribute('placeholder', /./);
+});

--- a/dashboard/tests/ui/ux-polish.spec.ts
+++ b/dashboard/tests/ui/ux-polish.spec.ts
@@ -52,6 +52,30 @@ test('definition list wraps long unbroken values instead of clipping them', asyn
     expect(metrics.cellRight).toBeLessThanOrEqual(metrics.listRight + 1);
 });
 
+test('command palette shortcuts stay inert while the search is hidden on small screens', async ({page}) => {
+    await page.setViewportSize({width: 390, height: 844});
+    await login(page);
+    // Let the layout effects settle before relying on the global shortcut listener.
+    await expect(page.getByRole('heading', {name: 'Dashboard'})).toBeVisible();
+
+    const paletteState = () => page.evaluate(() => {
+        const searchInput = document.querySelector('input[aria-label="Search navigation"]');
+        return {
+            ariaExpanded: searchInput?.getAttribute('aria-expanded'),
+            searchFocused: document.activeElement === searchInput,
+        };
+    });
+
+    await page.keyboard.press('Control+k');
+    await page.keyboard.press('/');
+
+    // The search control is display:none below 720px — shortcuts must not consume the
+    // event, focus the hidden input, or open results that can never be seen.
+    const state = await paletteState();
+    expect(state.ariaExpanded).toBe('false');
+    expect(state.searchFocused).toBe(false);
+});
+
 test('command palette shortcuts stay inert inside the native topology dialog', async ({page}) => {
     await login(page);
     const search = page.getByRole('combobox', {name: 'Search navigation'});


### PR DESCRIPTION
## Summary

UI/UX polish for the dashboard based on a full review of every page and interaction state (25 captured states + code review). Fixes one behavioral defect and five interaction/visual issues, all test-driven: each fix landed only after a failing Playwright test reproduced the problem.

## Changes

**Behavioral fix**
- **Collapsed sidebar**: the Security group trigger no longer renders as a dead button in the icon-only rail (its content only exists in expanded mode), and the duplicated icons are disambiguated — Audit Log now uses `History` (was `FileText`, same as Configuration), the Security group uses `Shield` (was `ShieldCheck`, same as Role).

**Interaction / visual polish**
- Audit event details timestamp no longer wraps mid-number: `DefinitionList` uses `break-words` with `min-w-0`, and the drawer shows seconds precision consistent with the audit table (CSV export unchanged, still full precision). `min-w-0` also keeps long unbroken values (64-char hashes) from overflowing the `overflow-hidden` list.
- Topology MiniMap is hidden below the `sm` breakpoint so it no longer occludes nodes on the small mobile canvas.
- Command palette: `Escape` now clears the query, closes the results, and blurs; `Ctrl/Cmd+K` focuses the search alongside `/`; both global shortcuts are suppressed while any modal surface (Radix sheet/dialog, alert dialog, or the native topology fullscreen `<dialog>`) is open, so they can't steal focus from a modal.
- Service instances: "Schema" → "Scheme" (column header, form label, `aria-label`), option labels `HTTP`/`HTTPS`, and Host/Port inputs gained placeholders.
- Test mock corrected to mirror real backend semantics: the config history index only contains superseded versions (never the current one), and hashes are realistic 64-char values.

## Testing

- [x] New `tests/ui/ux-polish.spec.ts` — 8 tests covering all fixes; each verified RED before implementation
- [x] Full UI suite passes: 18 passed, 1 skipped (opt-in real-backend)
- [x] Unit tests pass: 11 passed
- [x] `pnpm lint` clean, `pnpm build` succeeds
- [x] Visual verification of the collapsed sidebar and drawer states

## Review history

- Independent reviewer subagent: **Ready to merge** (no Critical/Important findings; the one actionable Minor — modal focus stealing — was fixed in this branch).
- Codex review (commit `7225f58b`): 3 P2 findings, all verified against the backend/codebase and resolved in `a2c43725`:
  - The no-op rollback guard was unreachable in production (the history index never contains the current version) — reverted, and the mock was corrected to the real semantics.
  - `DefinitionList` could clip unbroken 64-char hashes — fixed with `min-w-0` plus a regression test.
  - The modal guard missed the native topology `<dialog>` and the capture-handler path — both covered now, with a regression test.
- Codex follow-up (commit `a2c43725`): palette shortcuts also stayed active below 720px where the search is `display:none` — both handlers now require the search control to be visible; fixed in `5f8d8c12` with a mobile regression test.

## Notes

Follow-up candidates (out of scope here): inline login errors, drag-and-drop config import, clickable dashboard metric cards, docs screenshot re-capture, and updating `dashboard/CLAUDE.md` which still mentions Ant Design.

