### PR TITLE
feat(dashboard): improve mobile usability

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cosky-dashboard",
   "private": true,
-  "version": "5.8.0",
+  "version": "5.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -23,10 +23,9 @@
   grid-template-columns: 72px minmax(0, 1fr);
 }
 
-.app-sidebar {
-  position: sticky;
-  top: 0;
-  z-index: 30;
+.app-sidebar,
+.app-mobile-sidebar {
+  position: relative;
   display: flex;
   height: 100vh;
   flex-direction: column;
@@ -36,7 +35,14 @@
   box-shadow: 1px 0 0 rgba(255, 255, 255, 0.08);
 }
 
-.app-sidebar::after {
+.app-sidebar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+}
+
+.app-sidebar::after,
+.app-mobile-sidebar::after {
   content: '';
   position: absolute;
   inset: auto 0 0;
@@ -549,25 +555,6 @@
     visibility: hidden;
     transform: translateX(-100%);
     transition: transform 180ms ease, visibility 180ms ease;
-  }
-
-  .app-mobile-open .app-sidebar {
-    visibility: visible;
-    transform: translateX(0);
-  }
-
-  .app-mobile-open {
-    height: 100vh;
-    overflow: hidden;
-  }
-
-  .app-mobile-open::before {
-    content: '';
-    position: fixed;
-    z-index: 25;
-    inset: 0;
-    background: rgba(11, 11, 28, .42);
-    backdrop-filter: blur(2px);
   }
 
   .app-header {

--- a/dashboard/src/components/layout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout.tsx
@@ -44,6 +44,7 @@ import {useDrawer} from "../../contexts/DrawerContext.tsx";
 import CoskyLogo from "../../assets/cosky-logo-constellation.svg";
 import {Button} from '@/components/ui/button';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@/components/ui/collapsible';
+import {Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger} from '@/components/ui/sheet';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -76,6 +77,54 @@ const searchTargets = [...primaryItems, ...securityItems];
 // <dialog> whose implicit role carries no attribute, hence the dialog[open] check.
 const isModalOpen = () =>
     Boolean(document.querySelector('[role="dialog"], [role="alertdialog"], dialog[open]'));
+
+function SidebarContent({collapsed, currentPath, onCollapse, onNavigate}: {
+    collapsed: boolean;
+    currentPath: string;
+    onCollapse?: () => void;
+    onNavigate?: () => void;
+}) {
+    return <>
+        <NavLink to="/home" className="app-brand" onClick={onNavigate}>
+            <img src={CoskyLogo} alt="CoSky"/>
+            {!collapsed && <span className="app-brand-copy"><strong>CoSky</strong><small>Microservice Governance</small></span>}
+        </NavLink>
+        <nav className="app-nav" aria-label="Primary navigation">
+            {primaryItems.map(({to, label, icon: Icon}) => (
+                <NavLink key={to} to={to} title={label} onClick={onNavigate} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
+                    <Icon/>
+                    {!collapsed && <span>{label}</span>}
+                </NavLink>
+            ))}
+            {!collapsed ? (
+                <Collapsible defaultOpen={securityItems.some(item => item.to === currentPath)}>
+                    <CollapsibleTrigger asChild>
+                        <button type="button" className="app-nav-item app-nav-group" title="Security">
+                            <Shield/>
+                            <span>Security</span><ChevronDown className="app-nav-chevron"/>
+                        </button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="app-nav-submenu">
+                        {securityItems.map(({to, label, icon: Icon}) => (
+                            <NavLink key={to} to={to} onClick={onNavigate} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
+                                <Icon/>
+                                <span>{label}</span>
+                            </NavLink>
+                        ))}
+                    </CollapsibleContent>
+                </Collapsible>
+            ) : securityItems.map(({to, label, icon: Icon}) => (
+                <NavLink key={to} to={to} title={label} onClick={onNavigate} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
+                    <Icon/>
+                </NavLink>
+            ))}
+        </nav>
+        {onCollapse && <Button variant="ghost" className="app-collapse" onClick={onCollapse}>
+            {collapsed ? <ChevronsRight/> : <ChevronsLeft/>}
+            {!collapsed && 'Collapse'}
+        </Button>}
+    </>;
+}
 
 export const AuthenticatedLayout = () => {
     const [collapsed, setCollapsed] = useLayoutCollapsed();
@@ -185,55 +234,18 @@ export const AuthenticatedLayout = () => {
     };
 
     return (
-        <div className={cn('app-shell', collapsed && 'app-shell-collapsed', mobileOpen && 'app-mobile-open')} onKeyDownCapture={handleLayoutKeyDown}>
+        <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+        <div className={cn('app-shell', collapsed && 'app-shell-collapsed')} onKeyDownCapture={handleLayoutKeyDown}>
             <aside className="app-sidebar">
-                <NavLink to="/home" className="app-brand" onClick={() => setMobileOpen(false)}>
-                    <img src={CoskyLogo} alt="CoSky"/>
-                    {!collapsed && <span className="app-brand-copy"><strong>CoSky</strong><small>Microservice Governance</small></span>}
-                </NavLink>
-                <Button variant="ghost" size="icon-sm" className="app-mobile-close" onClick={() => setMobileOpen(false)} aria-label="Close navigation"><X/></Button>
-                <nav className="app-nav" aria-label="Primary navigation">
-                    {primaryItems.map(({to, label, icon: Icon}) => (
-                        <NavLink key={to} to={to} title={label} onClick={() => setMobileOpen(false)} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
-                            <Icon/>
-                            {!collapsed && <span>{label}</span>}
-                        </NavLink>
-                    ))}
-                    {!collapsed ? (
-                        <Collapsible defaultOpen={securityItems.some(item => item.to === location.pathname)}>
-                            <CollapsibleTrigger asChild>
-                                <button type="button" className="app-nav-item app-nav-group" title="Security">
-                                    <Shield/>
-                                    <span>Security</span><ChevronDown className="app-nav-chevron"/>
-                                </button>
-                            </CollapsibleTrigger>
-                            <CollapsibleContent className="app-nav-submenu">
-                                {securityItems.map(({to, label, icon: Icon}) => (
-                                    <NavLink key={to} to={to} onClick={() => setMobileOpen(false)} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
-                                        <Icon/>
-                                        <span>{label}</span>
-                                    </NavLink>
-                                ))}
-                            </CollapsibleContent>
-                        </Collapsible>
-                    ) : securityItems.map(({to, label, icon: Icon}) => (
-                        <NavLink key={to} to={to} title={label} onClick={() => setMobileOpen(false)} className={({isActive}) => cn('app-nav-item', isActive && 'active')}>
-                            <Icon/>
-                        </NavLink>
-                    ))}
-                </nav>
-                <Button variant="ghost" className="app-collapse" onClick={() => setCollapsed(!collapsed)}>
-                    {collapsed ? <ChevronsRight/> : <ChevronsLeft/>}
-                    {!collapsed && 'Collapse'}
-                </Button>
+                <SidebarContent collapsed={collapsed} currentPath={location.pathname} onCollapse={() => setCollapsed(!collapsed)}/>
             </aside>
 
             <div className="app-main">
                 <header className="app-header">
                     <div className="app-header-start">
-                        <Button variant="ghost" size="icon" className="app-mobile-menu" onClick={() => {setCollapsed(false); setMobileOpen(true);}} aria-label="Open navigation">
-                            <Menu/>
-                        </Button>
+                        <SheetTrigger asChild>
+                            <Button variant="ghost" size="icon" className="app-mobile-menu" aria-label="Open navigation"><Menu/></Button>
+                        </SheetTrigger>
                         <Button variant="ghost" size="icon-sm" className="app-desktop-menu" onClick={() => setCollapsed(!collapsed)} aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}>
                             {collapsed ? <PanelLeftOpen/> : <PanelLeftClose/>}
                         </Button>
@@ -343,5 +355,15 @@ export const AuthenticatedLayout = () => {
                 </main>
             </div>
         </div>
+        <SheetContent side="left" showCloseButton={false} aria-modal="true" className="w-[232px] max-w-none gap-0 border-0 bg-[#111127] p-0 text-[#dadae7] sm:max-w-none">
+            <SheetTitle className="sr-only">Navigation</SheetTitle>
+            <div className="app-mobile-sidebar">
+                <SheetClose asChild>
+                    <Button variant="ghost" size="icon-sm" className="app-mobile-close" aria-label="Close navigation"><X/></Button>
+                </SheetClose>
+                <SidebarContent collapsed={false} currentPath={location.pathname} onNavigate={() => setMobileOpen(false)}/>
+            </div>
+        </SheetContent>
+        </Sheet>
     );
 };

--- a/dashboard/src/pages/audit/AuditLogPage.tsx
+++ b/dashboard/src/pages/audit/AuditLogPage.tsx
@@ -129,17 +129,23 @@ export function AuditLogPage() {
         {
             header: 'Timestamp',
             key: 'opTime',
+            className: 'max-sm:hidden',
             cell: record => dayjs(record.opTime).format('YYYY-MM-DD HH:mm:ss'),
         },
-        {header: 'Operator', accessor: 'operator', key: 'operator'},
-        {header: 'Client IP', accessor: 'ip', key: 'ip'},
+        {header: 'Operator', accessor: 'operator', key: 'operator', className: 'max-sm:hidden'},
+        {header: 'Client IP', accessor: 'ip', key: 'ip', className: 'max-sm:hidden'},
         {
             header: 'Resource',
             key: 'resource',
             className: 'max-w-80',
-            cell: record => <code className="block truncate text-xs" title={record.resource}>{record.resource}</code>,
+            cell: record => <>
+                <code className="block truncate text-xs" title={record.resource}>{record.resource}</code>
+                <span className="mt-1 block text-xs text-muted-foreground sm:hidden">
+                    {record.action} · {dayjs(record.opTime).format('MM-DD HH:mm')}
+                </span>
+            </>,
         },
-        {header: 'Action', accessor: 'action', key: 'action'},
+        {header: 'Action', accessor: 'action', key: 'action', className: 'max-sm:hidden'},
         {
             header: 'Status',
             key: 'status',
@@ -148,7 +154,7 @@ export function AuditLogPage() {
         {
             header: 'Message',
             key: 'msg',
-            className: 'max-w-56',
+            className: 'max-w-56 max-sm:hidden',
             cell: record => record.msg
                 ? <span className="block truncate" title={record.msg}>{record.msg}</span>
                 : <span className="text-muted-foreground">—</span>,
@@ -156,11 +162,11 @@ export function AuditLogPage() {
         {
             header: 'Details',
             key: 'details',
-            className: 'w-24 text-right',
-            cell: record => <Button variant="ghost" size="sm" onClick={() => openDrawer(
+            className: 'w-24 text-right max-sm:sticky max-sm:right-0 max-sm:z-10 max-sm:w-12 max-sm:bg-card max-sm:shadow-[-8px_0_8px_-8px_rgba(0,0,0,0.25)]',
+            cell: record => <Button variant="ghost" size="sm" className="max-sm:size-10 max-sm:px-0" aria-label="Details" onClick={() => openDrawer(
                 <AuditLogDetails log={record}/>,
                 {title: 'Audit Event Details', width: 'min(720px, 92vw)'},
-            )}><Eye/> Details</Button>,
+            )}><Eye/> <span className="hidden sm:inline">Details</span></Button>,
         },
     ];
 

--- a/dashboard/src/pages/dashboard/DashboardPage.tsx
+++ b/dashboard/src/pages/dashboard/DashboardPage.tsx
@@ -95,6 +95,9 @@ export function DashboardPage() {
                                     {value.toLocaleString()}
                                     {detail && <span className="ml-1 text-sm font-normal text-muted-foreground">{detail}</span>}
                                 </p>
+                                {label === 'Healthy Services' && <Link to="/service" className="mt-1 block text-xs font-medium text-destructive hover:underline">
+                                    {Math.max(0, stat.services.total - stat.services.health)} Unhealthy
+                                </Link>}
                             </div>
                         </div>
                     ))}

--- a/dashboard/tests/ui/dashboard.spec.ts
+++ b/dashboard/tests/ui/dashboard.spec.ts
@@ -600,14 +600,21 @@ test('mobile layout keeps navigation and dashboard controls usable', async ({pag
     await expect(page.getByRole('button', {name: 'Open navigation'})).toBeVisible();
     await expect(page.getByRole('heading', {name: 'Dashboard'})).toBeVisible();
     await expect(page.getByText('Healthy Services')).toBeVisible();
+    await expect(page.getByRole('link', {name: '6 Unhealthy'})).toBeVisible();
     const healthyCard = await page.getByText('Healthy Services').evaluate(element => element.parentElement?.parentElement?.getBoundingClientRect().toJSON());
     const instancesCard = await page.getByText('Instances', {exact: true}).evaluate(element => element.parentElement?.parentElement?.getBoundingClientRect().toJSON());
     expect(healthyCard?.y).toBe(instancesCard?.y);
     const topology = page.locator('[data-slot="card"]').filter({hasText: 'Service Topology'}).locator('[data-slot="card-content"]');
     expect((await topology.boundingBox())?.height).toBeLessThanOrEqual(400);
     await page.getByRole('button', {name: 'Open navigation'}).click();
+    const navigation = page.getByRole('dialog', {name: 'Navigation'});
+    await expect(navigation).toBeVisible();
+    await expect(navigation).toHaveAttribute('aria-modal', 'true');
+    await expect(page.locator('[data-slot="sheet-overlay"]')).toBeVisible();
     await expect(page.getByRole('button', {name: 'Close navigation'})).toBeVisible();
     await expect(page.getByRole('link', {name: 'Configuration'})).toBeVisible();
+    for (let index = 0; index < 12; index++) await page.keyboard.press('Tab');
+    expect(await page.evaluate(() => document.activeElement?.closest('[role="dialog"]') !== null)).toBe(true);
     await page.getByRole('button', {name: 'Close navigation'}).click();
     await expect(page.getByRole('button', {name: 'Open navigation'})).toBeVisible();
 
@@ -624,6 +631,19 @@ test('mobile layout keeps navigation and dashboard controls usable', async ({pag
     await expect(page.getByRole('dialog', {name: 'Add [api-gateway] Instance'})).toBeVisible();
     await expect(page.getByRole('button', {name: 'Submit', exact: true})).toBeInViewport();
     await page.getByRole('button', {name: 'Close', exact: true}).click();
+
+    await page.goto('/audit-log');
+    const failedStatus = page.getByRole('cell', {name: '500'});
+    const details = page.getByRole('button', {name: 'Details'}).first();
+    const isHorizontallyVisible = (element: Element) => {
+        const cell = element.getBoundingClientRect();
+        const table = element.closest('[data-slot="table-container"]')!.getBoundingClientRect();
+        return cell.left >= table.left && cell.right <= table.right;
+    };
+    expect(await failedStatus.evaluate(isHorizontallyVisible)).toBe(true);
+    expect(await details.evaluate(isHorizontallyVisible)).toBe(true);
+    const auditTableOverflow = await page.locator('[data-slot="table-container"]').evaluate(element => element.scrollWidth > element.clientWidth);
+    expect(auditTableOverflow).toBe(false);
 
     const horizontalOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
     expect(horizontalOverflow).toBe(false);

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosky
-version=5.8.0
+version=5.8.1
 description=High-performance, low-cost microservice governance platform. Service Discovery and Configuration Service.
 website=https://github.com/Ahoo-Wang/cosky
 issues=https://github.com/Ahoo-Wang/cosky/issues

--- a/wiki/guide/deployment-kubernetes.md
+++ b/wiki/guide/deployment-kubernetes.md
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           ports:
             - name: http
               containerPort: 8080
@@ -77,7 +77,7 @@ spec:
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
 ::: tip Image tag
-The manifests below use the current release `5.8.0` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). The in-repo manifests ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)) still pin the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` on Docker Hub.
+The manifests below use the current release `5.8.1` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). The in-repo manifests ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)) still pin the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` on Docker Hub.
 :::
 
 ## Clustered Redis Deployment
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           env:
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:

--- a/wiki/guide/deployment-standalone.md
+++ b/wiki/guide/deployment-standalone.md
@@ -21,10 +21,10 @@ cd dashboard && pnpm install && pnpm build && cd ..
 ./gradlew :cosky-rest-api:distTar
 
 # Extract
-tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.0.tar
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.1.tar
 
 # Enter the directory
-cd cosky-rest-api-5.8.0
+cd cosky-rest-api-5.8.1
 ```
 
 The distribution bundles the dashboard static files from `dashboard/dist` into `ui/`.
@@ -32,7 +32,7 @@ The distribution bundles the dashboard static files from `dashboard/dist` into `
 The extracted directory structure contains:
 
 ```
-cosky-rest-api-5.8.0/
+cosky-rest-api-5.8.1/
   bin/
     cosky-rest-api     # Startup script (Unix)
   config/

--- a/wiki/guide/getting-started.md
+++ b/wiki/guide/getting-started.md
@@ -59,7 +59,7 @@ graph LR
 #### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.8.0"
+val coskyVersion = "5.8.1"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
@@ -74,7 +74,7 @@ dependencies {
 
 ```xml
 <properties>
-    <cosky.version>5.8.0</cosky.version>
+    <cosky.version>5.8.1</cosky.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -293,7 +293,7 @@ graph TB
 
 ## References
 
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.8.0`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.8.1`)
 - [CoSkyProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt) -- core configuration properties
 - [CoSkyConfigProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt) -- config starter properties
 - [CoSkyDiscoveryProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt) -- discovery starter properties

--- a/wiki/guide/installation.md
+++ b/wiki/guide/installation.md
@@ -53,7 +53,7 @@ Add CoSky starters to your Spring Cloud application. These are published to Mave
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.8.0"
+val coskyVersion = "5.8.1"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
@@ -74,7 +74,7 @@ dependencies {
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosky.version>5.8.0</cosky.version>
+        <cosky.version>5.8.1</cosky.version>
     </properties>
 
     <dependencyManagement>
@@ -140,8 +140,8 @@ cd dashboard && pnpm install && pnpm build && cd ..
 ./gradlew :cosky-rest-api:distTar
 
 # Extract (the archive name includes the version)
-tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.0.tar
-cd cosky-rest-api-5.8.0
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.1.tar
+cd cosky-rest-api-5.8.1
 
 # Run with Redis connection
 bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
@@ -229,7 +229,7 @@ spec:
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           startupProbe:
             httpGet:
               port: http
@@ -264,7 +264,7 @@ spec:
           name: volume-localtime
 ```
 
-> **Note:** The example above uses the current release `5.8.0`. The in-repo manifest ([k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)) still pins the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` from Docker Hub.
+> **Note:** The example above uses the current release `5.8.1`. The in-repo manifest ([k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)) still pins the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` from Docker Hub.
 
 Source: [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -313,7 +313,7 @@ spec:
               value: 30s
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           startupProbe:
             httpGet:
               port: http
@@ -510,7 +510,7 @@ Source: [README.md:238-246](https://github.com/Ahoo-Wang/CoSky/blob/main/README.
 ## References
 
 - [build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/build.gradle.kts) -- root build configuration with JVM 17 toolchain
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.8.0`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.8.1`)
 - [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) -- all module definitions
 - [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml) -- Kubernetes deployment (standalone Redis)
 - [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml) -- Kubernetes deployment (Redis Cluster)

--- a/wiki/guide/onboarding-contributor.md
+++ b/wiki/guide/onboarding-contributor.md
@@ -17,7 +17,7 @@ The name comes from **Co** (configuration) + **Sky** (service discovery). The pr
 
 - Repository: [https://github.com/Ahoo-Wang/CoSky](https://github.com/Ahoo-Wang/CoSky)
 - Group ID: `me.ahoo.cosky`
-- Current version: 5.8.0
+- Current version: 5.8.1
 
 ### Tech Stack
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -257,7 +257,7 @@ graph LR
 #### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.8.0"
+val coskyVersion = "5.8.1"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
@@ -272,7 +272,7 @@ dependencies {
 
 ```xml
 <properties>
-    <cosky.version>5.8.0</cosky.version>
+    <cosky.version>5.8.1</cosky.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -491,7 +491,7 @@ graph TB
 
 ## References
 
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.8.0`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- current version (`5.8.1`)
 - [CoSkyProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt) -- core configuration properties
 - [CoSkyConfigProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt) -- config starter properties
 - [CoSkyDiscoveryProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt) -- discovery starter properties
@@ -550,7 +550,7 @@ Add CoSky starters to your Spring Cloud application. These are published to Mave
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-val coskyVersion = "5.8.0"
+val coskyVersion = "5.8.1"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
@@ -571,7 +571,7 @@ dependencies {
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosky.version>5.8.0</cosky.version>
+        <cosky.version>5.8.1</cosky.version>
     </properties>
 
     <dependencyManagement>
@@ -637,8 +637,8 @@ cd dashboard && pnpm install && pnpm build && cd ..
 ./gradlew :cosky-rest-api:distTar
 
 # Extract (the archive name includes the version)
-tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.0.tar
-cd cosky-rest-api-5.8.0
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.1.tar
+cd cosky-rest-api-5.8.1
 
 # Run with Redis connection
 bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
@@ -726,7 +726,7 @@ spec:
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           startupProbe:
             httpGet:
               port: http
@@ -761,7 +761,7 @@ spec:
           name: volume-localtime
 ```
 
-> **Note:** The example above uses the current release `5.8.0`. The in-repo manifest ([k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)) still pins the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` from Docker Hub.
+> **Note:** The example above uses the current release `5.8.1`. The in-repo manifest ([k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)) still pins the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` from Docker Hub.
 
 Source: [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -810,7 +810,7 @@ spec:
               value: 30s
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           startupProbe:
             httpGet:
               port: http
@@ -1007,7 +1007,7 @@ Source: [README.md:238-246](https://github.com/Ahoo-Wang/CoSky/blob/main/README.
 ## References
 
 - [build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/build.gradle.kts) -- root build configuration with JVM 17 toolchain
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.8.0`)
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- project version (`5.8.1`)
 - [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) -- all module definitions
 - [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml) -- Kubernetes deployment (standalone Redis)
 - [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml) -- Kubernetes deployment (Redis Cluster)
@@ -5133,7 +5133,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           ports:
             - name: http
               containerPort: 8080
@@ -5177,7 +5177,7 @@ spec:
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
 ::: tip Image tag
-The manifests below use the current release `5.8.0` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). The in-repo manifests ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)) still pin the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` on Docker Hub.
+The manifests below use the current release `5.8.1` ([gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)). The in-repo manifests ([k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)) still pin the older `5.3.5` tag — prefer the current release, or `ahoowang/cosky:latest` on Docker Hub.
 :::
 
 ## Clustered Redis Deployment
@@ -5205,7 +5205,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           env:
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:
@@ -5501,10 +5501,10 @@ cd dashboard && pnpm install && pnpm build && cd ..
 ./gradlew :cosky-rest-api:distTar
 
 # Extract
-tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.0.tar
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.1.tar
 
 # Enter the directory
-cd cosky-rest-api-5.8.0
+cd cosky-rest-api-5.8.1
 ```
 
 The distribution bundles the dashboard static files from `dashboard/dist` into `ui/`.
@@ -5512,7 +5512,7 @@ The distribution bundles the dashboard static files from `dashboard/dist` into `
 The extracted directory structure contains:
 
 ```
-cosky-rest-api-5.8.0/
+cosky-rest-api-5.8.1/
   bin/
     cosky-rest-api     # Startup script (Unix)
   config/

--- a/wiki/zh/guide/deployment-kubernetes.md
+++ b/wiki/zh/guide/deployment-kubernetes.md
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           ports:
             - name: http
               containerPort: 8080
@@ -77,7 +77,7 @@ spec:
 <!-- Sources: k8s/deployment/cosky.yml:1, cosky-rest-api/src/main/resources/application.yaml:1 -->
 
 ::: tip 镜像标签
-下方清单使用当前发布版本 `5.8.0`（[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)）。仓库内置清单（[k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)）仍固定为较旧的 `5.3.5` 标签——建议使用当前发布版本，或 Docker Hub 上的 `ahoowang/cosky:latest`。
+下方清单使用当前发布版本 `5.8.1`（[gradle.properties:14](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties#L14)）。仓库内置清单（[k8s/deployment/cosky.yml:27](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml#L27)）仍固定为较旧的 `5.3.5` 标签——建议使用当前发布版本，或 Docker Hub 上的 `ahoowang/cosky:latest`。
 :::
 
 ## 集群化 Redis 部署
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: cosky
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           env:
             - name: SPRING_DATA_REDIS_CLUSTER_NODES
               valueFrom:

--- a/wiki/zh/guide/deployment-standalone.md
+++ b/wiki/zh/guide/deployment-standalone.md
@@ -21,10 +21,10 @@ cd dashboard && pnpm install && pnpm build && cd ..
 ./gradlew :cosky-rest-api:distTar
 
 # 解压
-tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.0.tar
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.1.tar
 
 # 进入目录
-cd cosky-rest-api-5.8.0
+cd cosky-rest-api-5.8.1
 ```
 
 发行版会将 `dashboard/dist` 中的 Dashboard 静态文件打包到 `ui/` 目录。
@@ -32,7 +32,7 @@ cd cosky-rest-api-5.8.0
 解压后的目录结构包含：
 
 ```
-cosky-rest-api-5.8.0/
+cosky-rest-api-5.8.1/
   bin/
     cosky-rest-api     # 启动脚本 (Unix)
   config/

--- a/wiki/zh/guide/getting-started.md
+++ b/wiki/zh/guide/getting-started.md
@@ -59,7 +59,7 @@ graph LR
 #### Gradle（Kotlin DSL）
 
 ```kotlin
-val coskyVersion = "5.8.0"
+val coskyVersion = "5.8.1"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
@@ -74,7 +74,7 @@ dependencies {
 
 ```xml
 <properties>
-    <cosky.version>5.8.0</cosky.version>
+    <cosky.version>5.8.1</cosky.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -293,7 +293,7 @@ graph TB
 
 ## 参考
 
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 当前版本（`5.8.0`）
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 当前版本（`5.8.1`）
 - [CoSkyProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-core/src/main/kotlin/me/ahoo/cosky/spring/cloud/CoSkyProperties.kt) -- 核心配置属性
 - [CoSkyConfigProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-config/src/main/kotlin/me/ahoo/cosky/config/spring/cloud/CoSkyConfigProperties.kt) -- 配置 Starter 属性
 - [CoSkyDiscoveryProperties.kt](https://github.com/Ahoo-Wang/CoSky/blob/main/cosky-spring-cloud-starter-discovery/src/main/kotlin/me/ahoo/cosky/discovery/spring/cloud/discovery/CoSkyDiscoveryProperties.kt) -- 发现 Starter 属性

--- a/wiki/zh/guide/installation.md
+++ b/wiki/zh/guide/installation.md
@@ -53,7 +53,7 @@ flowchart TD
 ### Gradle（Kotlin DSL）
 
 ```kotlin
-val coskyVersion = "5.8.0"
+val coskyVersion = "5.8.1"
 
 dependencies {
     implementation(platform("me.ahoo.cosky:cosky-bom:${coskyVersion}"))
@@ -74,7 +74,7 @@ dependencies {
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosky.version>5.8.0</cosky.version>
+        <cosky.version>5.8.1</cosky.version>
     </properties>
 
     <dependencyManagement>
@@ -140,8 +140,8 @@ cd dashboard && pnpm install && pnpm build && cd ..
 ./gradlew :cosky-rest-api:distTar
 
 # 解压（归档文件名包含版本号）
-tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.0.tar
-cd cosky-rest-api-5.8.0
+tar -xvf cosky-rest-api/build/distributions/cosky-rest-api-5.8.1.tar
+cd cosky-rest-api-5.8.1
 
 # 使用 Redis 连接运行
 bin/cosky-rest-api --server.port=8080 --spring.data.redis.url=redis://localhost:6379
@@ -229,7 +229,7 @@ spec:
               value: redis-pwd
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           startupProbe:
             httpGet:
               port: http
@@ -264,7 +264,7 @@ spec:
           name: volume-localtime
 ```
 
-> **注意：** 上述示例使用当前发布版本 `5.8.0`。仓库内置清单（[k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)）仍固定为较旧的 `5.3.5` 标签——建议使用当前发布版本，或 Docker Hub 上的 `ahoowang/cosky:latest`。
+> **注意：** 上述示例使用当前发布版本 `5.8.1`。仓库内置清单（[k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)）仍固定为较旧的 `5.3.5` 标签——建议使用当前发布版本，或 Docker Hub 上的 `ahoowang/cosky:latest`。
 
 源码：[k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml)
 
@@ -313,7 +313,7 @@ spec:
               value: 30s
             - name: TZ
               value: Asia/Shanghai
-          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.0
+          image: registry.cn-shanghai.aliyuncs.com/ahoo/cosky:5.8.1
           startupProbe:
             httpGet:
               port: http
@@ -510,7 +510,7 @@ REST API 服务器运行后，通过以下地址访问基于 Web 的管理界面
 ## 参考
 
 - [build.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/build.gradle.kts) -- 根构建配置，使用 JVM 17 工具链
-- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 项目版本（`5.8.0`）
+- [gradle.properties](https://github.com/Ahoo-Wang/CoSky/blob/main/gradle.properties) -- 项目版本（`5.8.1`）
 - [settings.gradle.kts](https://github.com/Ahoo-Wang/CoSky/blob/main/settings.gradle.kts) -- 所有模块定义
 - [k8s/deployment/cosky.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky.yml) -- Kubernetes 部署（单机 Redis）
 - [k8s/deployment/cosky-cluster.yml](https://github.com/Ahoo-Wang/CoSky/blob/main/k8s/deployment/cosky-cluster.yml) -- Kubernetes 部署（Redis 集群）

--- a/wiki/zh/guide/onboarding-contributor.md
+++ b/wiki/zh/guide/onboarding-contributor.md
@@ -17,7 +17,7 @@ CoSky 是一个高性能的微服务治理平台，提供**服务发现**和**�
 
 - 仓库地址：[https://github.com/Ahoo-Wang/CoSky](https://github.com/Ahoo-Wang/CoSky)
 - Group ID：`me.ahoo.cosky`
-- 当前版本：5.8.0
+- 当前版本：5.8.1
 
 ### 技术栈
 


### PR DESCRIPTION
## Summary

- expose the unhealthy service count with a direct service-page entry point
- reuse the existing Sheet for modal mobile navigation and focus containment
- keep audit status and details visible without horizontal table overflow on mobile

## Verification

- pnpm build
- pnpm test:unit (11 passed)
- pnpm test:ui tests/ui/dashboard.spec.ts tests/ui/ux-polish.spec.ts (19 passed)
- pnpm exec eslint on the changed TypeScript files